### PR TITLE
feat: add linux-arm64 support

### DIFF
--- a/.github/workflows/build-terre-linux-arm64.yml
+++ b/.github/workflows/build-terre-linux-arm64.yml
@@ -1,0 +1,96 @@
+name: Build and Deploy on Linux
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build ARM64 Binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Build Stage 1
+        run: |
+          echo "Welcome to build WebGAL Origine, the editor of WebGAL platform."
+          # 安装依赖
+          yarn install --frozen-lockfile
+          # 清理
+          test -d release && rm -rf release
+          mkdir release
+          # 进入 Terre 目录
+          cd packages/terre2
+          yarn run build
+      - name: Build pkg ARM64
+        uses: pguyot/arm-runner-action@v2
+        with:
+          base_image: raspios_lite_arm64:latest
+          bind_mount_repository: true
+          commands: |
+            apt-get update
+            apt-get install -y curl sudo
+            # Install Node.js v18.x
+            curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+            apt-get install -y nodejs
+            # Enable yarn
+            corepack prepare yarn@1.22.19 --activate
+            corepack enable yarn
+            cd packages/terre2
+            yarn run pkg:linux-arm64
+      - name: Build Stage 2
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          sudo chmod 777 -R .
+          cd packages/terre2/dist
+          cp -r WebGAL_Terre  ../../../release
+          rm WebGAL_Terre
+          cd ../
+          mkdir Exported_Games
+          cp -r public assets Exported_Games ../../release
+          cd ../../
+          # 进入 Origine 目录
+          cd packages/origine2
+          # 低内存，使用下一行限制内存使用
+          # export NODE_OPTIONS=--max_old_space_size=512000
+          yarn run build
+          cp -rf dist/* ../../release/public/
+          cd ../../
+          # 进入 Electron 目录
+          cd packages/WebGAL-electron
+          yarn install --frozen-lockfile
+          yarn run build:arm64
+          mkdir ../../release/assets/templates/WebGAL_Electron_Template
+          cp -rf build/linux-arm64-unpacked/* ../../release/assets/templates/WebGAL_Electron_Template/
+          cd ../../
+          # 克隆 WebGAL Android 模板
+          cd release/assets/templates/
+          git clone https://github.com/nini22P/WebGAL-Android.git
+          mv WebGAL-Android WebGAL_Android_Template
+          # MainActivity.kt 移动到主文件夹防止误删
+          mv WebGAL_Android_Template/app/src/main/java/com/openwebgal/demo/MainActivity.kt WebGAL_Android_Template/app/src/main/java/MainActivity.kt
+          cd ../../../
+          cd release
+          # 删除冗余文件
+          rm -rf Exported_Games/*
+          rm -rf public/games/*
+          rm -rf public/games/.gitkeep
+          rm -rf assets/templates/WebGAL_Template/game/video/*
+          rm -rf assets/templates/WebGAL_Template/game/video/.gitkeep
+          rm -rf assets/templates/WebGAL_Android_Template/.github
+          rm -rf assets/templates/WebGAL_Android_Template/.git
+          rm -rf assets/templates/WebGAL_Android_Template/.gitattributes
+          rm -rf assets/templates/WebGAL_Android_Template/app/src/main/assets/webgal/.gitkeep
+          rm -rf assets/templates/WebGAL_Android_Template/app/src/main/java/com
+          echo "WebGAL Origine is now ready to be deployed."
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: WebGAL_Terre
+          path: release

--- a/.github/workflows/pr-check-linux-arm64.yml
+++ b/.github/workflows/pr-check-linux-arm64.yml
@@ -1,0 +1,98 @@
+name: Build Check Linux (ARM64)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  build:
+    name: Build ARM64 Binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Build Stage 1
+        run: |
+          echo "Welcome to build WebGAL Origine, the editor of WebGAL platform."
+          # 安装依赖
+          yarn install --frozen-lockfile
+          # 清理
+          test -d release && rm -rf release
+          mkdir release
+          # 进入 Terre 目录
+          cd packages/terre2
+          yarn run build
+      - name: Build pkg ARM64
+        uses: pguyot/arm-runner-action@v2
+        with:
+          base_image: raspios_lite_arm64:latest
+          bind_mount_repository: true
+          commands: |
+            apt-get update
+            apt-get install -y curl sudo
+            # Install Node.js v18.x
+            curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+            apt-get install -y nodejs
+            # Enable yarn
+            corepack prepare yarn@1.22.19 --activate
+            corepack enable yarn
+            cd packages/terre2
+            yarn run pkg:linux-arm64
+      - name: Build Stage 2
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          sudo chmod 777 -R .
+          cd packages/terre2/dist
+          cp -r WebGAL_Terre  ../../../release
+          rm WebGAL_Terre
+          cd ../
+          mkdir Exported_Games
+          cp -r public assets Exported_Games ../../release
+          cd ../../
+          # 进入 Origine 目录
+          cd packages/origine2
+          # 低内存，使用下一行限制内存使用
+          # export NODE_OPTIONS=--max_old_space_size=512000
+          yarn run build
+          cp -rf dist/* ../../release/public/
+          cd ../../
+          # 进入 Electron 目录
+          cd packages/WebGAL-electron
+          yarn install --frozen-lockfile
+          yarn run build:arm64
+          mkdir ../../release/assets/templates/WebGAL_Electron_Template
+          cp -rf build/linux-arm64-unpacked/* ../../release/assets/templates/WebGAL_Electron_Template/
+          cd ../../
+          # 克隆 WebGAL Android 模板
+          cd release/assets/templates/
+          git clone https://github.com/nini22P/WebGAL-Android.git
+          mv WebGAL-Android WebGAL_Android_Template
+          # MainActivity.kt 移动到主文件夹防止误删
+          mv WebGAL_Android_Template/app/src/main/java/com/openwebgal/demo/MainActivity.kt WebGAL_Android_Template/app/src/main/java/MainActivity.kt
+          cd ../../../
+          cd release
+          # 删除冗余文件
+          rm -rf Exported_Games/*
+          rm -rf public/games/*
+          rm -rf public/games/.gitkeep
+          rm -rf assets/templates/WebGAL_Template/game/video/*
+          rm -rf assets/templates/WebGAL_Template/game/video/.gitkeep
+          rm -rf assets/templates/WebGAL_Android_Template/.github
+          rm -rf assets/templates/WebGAL_Android_Template/.git
+          rm -rf assets/templates/WebGAL_Android_Template/.gitattributes
+          rm -rf assets/templates/WebGAL_Android_Template/app/src/main/assets/webgal/.gitkeep
+          rm -rf assets/templates/WebGAL_Android_Template/app/src/main/java/com
+          echo "WebGAL Origine is now ready to be deployed."
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: WebGAL_Terre
+          path: release

--- a/packages/WebGAL-electron/package.json
+++ b/packages/WebGAL-electron/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "electron .",
     "build": "electron-builder",
-    "build-universal": "electron-builder --universal"
+    "build-universal": "electron-builder --universal",
+    "build:arm64": "electron-builder --arm64"
   },
   "devDependencies": {
     "electron": "^18.3.7",

--- a/packages/terre2/package.json
+++ b/packages/terre2/package.json
@@ -19,7 +19,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "pkg": "cd dist && pkg main.js -o WebGAL_Terre"
+    "pkg": "cd dist && pkg main.js -o WebGAL_Terre",
+    "pkg:linux-arm64": "cd dist && pkg main.js -o WebGAL_Terre -t node18-linux-arm64"
   },
   "dependencies": {
     "@nestjs/common": "^9.0.5",

--- a/release-linux-arm64.sh
+++ b/release-linux-arm64.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eu
+
+echo "Welcome to build WebGAL Origine, the editor of WebGAL platform."
+# 安装依赖
+yarn install --frozen-lockfile
+
+# 清理
+test -d release && rm -rf release
+
+mkdir release
+
+# 进入 Terre 目录
+cd packages/terre2
+yarn run build
+yarn run pkg:linux-arm64
+cd dist
+cp -r WebGAL_Terre  ../../../release
+rm WebGAL_Terre
+cd ../
+mkdir Exported_Games
+cp -r public assets Exported_Games ../../release
+cd ../../
+
+# 进入 Origine 目录
+cd packages/origine2
+# 低内存，使用下一行限制内存使用
+# export NODE_OPTIONS=--max_old_space_size=512000
+yarn run build
+cp -rf dist/* ../../release/public/
+cd ../../
+
+# 进入 Electron 目录
+cd packages/WebGAL-electron
+yarn install --frozen-lockfile
+yarn run build:arm64
+mkdir ../../release/assets/templates/WebGAL_Electron_Template
+cp -rf build/linux-arm64-unpacked/* ../../release/assets/templates/WebGAL_Electron_Template/
+cd ../../
+
+# 克隆 WebGAL Android 模板
+cd release/assets/templates/
+git clone https://github.com/nini22P/WebGAL-Android.git
+mv WebGAL-Android WebGAL_Android_Template
+# MainActivity.kt 移动到主文件夹防止误删
+mv WebGAL_Android_Template/app/src/main/java/com/openwebgal/demo/MainActivity.kt WebGAL_Android_Template/app/src/main/java/MainActivity.kt
+cd ../../../
+
+cd release
+
+# 删除冗余文件
+rm -rf Exported_Games/*
+rm -rf public/games/*
+rm -rf public/games/.gitkeep
+rm -rf assets/templates/WebGAL_Template/game/video/*
+rm -rf assets/templates/WebGAL_Template/game/video/.gitkeep
+rm -rf assets/templates/WebGAL_Android_Template/.github
+rm -rf assets/templates/WebGAL_Android_Template/.git
+rm -rf assets/templates/WebGAL_Android_Template/.gitattributes
+rm -rf assets/templates/WebGAL_Android_Template/app/src/main/assets/webgal/.gitkeep
+rm -rf assets/templates/WebGAL_Android_Template/app/src/main/java/com
+
+echo "WebGAL Origine is now ready to be deployed."


### PR DESCRIPTION
This may add the Linux ARM64 support for WebGAL_Terre. (Related to #103)

BTW I haven't tested the Artifacts yet, as I don't have an arm64 device too. Log seems no error.

This PR contains the `release-linux-arm64.sh` and GitHub Actions support, **but** in order to reduce the build time of GitHub Actions as much as possible and optimize the build efficiency, I just build `pkg` on ARM64 (qemu), resulting in Actions **not** using `release-linux-arm64.sh`, which is a huge disadvantage I think.
