### PR TITLE
Empty the CG/BGM File when modifying the Unlock CG/BGM Type

### DIFF
--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/UnlockExtra.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/UnlockExtra.tsx
@@ -32,6 +32,9 @@ export default function UnlockExtra(props: ISentenceEditorProps) {
           { key: "unlockBgm", text: t('type.options.bgm') }
         ]}
         selectedKey={unlockType.value} onChange={(event, option) => {
+          if(option?.key?.toString() !== unlockType.value){
+            fileName.set("");
+          }
           unlockType.set(option?.key?.toString() ?? "");
           submit();
         }} />


### PR DESCRIPTION
The file is still a wrong type selection when I switch file types,Empty the file when modifying the Unlock Type.