### PR TITLE
Changed 'EditorSidebarControl' component's icons.

### DIFF
--- a/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
+++ b/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
@@ -48,10 +48,8 @@ export default function EditorSidebarControl() {
   return <div className={styles.editor_sidebar_control}>
     <div onClick={switchPreview}>
       <SidebarIcons isActive={state.showPreview}>
-        <>
-          {state.showPreview && <IconButton iconProps={previewOpenIcon} title="showPreview" ariaLabel="showPreview" />}
-          {!state.showPreview && <IconButton iconProps={previewCloseIcon} title="closePreview" ariaLabel="closePreview" />}
-        </>
+        <IconButton iconProps={state.showPreview ? previewOpenIcon : previewCloseIcon}
+          title={t("preview.title")} ariaLabel={t("preview.title")} />
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.gameconfig)} style={{ margin: "auto 0 0 0" }}>

--- a/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
+++ b/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
@@ -2,8 +2,10 @@ import styles from "./editorSideBar.module.scss";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../../store/origineStore";
 import { ReactElement } from "react";
-import { FolderOpen, PlayTwo, PreviewCloseOne, PreviewOpen, SettingConfig } from "@icon-park/react";
 import { setEditorPreviewShow, setEditorSidebarTag, sidebarTag } from "../../../store/statusReducer";
+import useTrans from "@/hooks/useTrans";
+import { IIconProps } from '@fluentui/react';
+import { IconButton } from '@fluentui/react/lib/Button';
 
 interface ISidebarIconsProps {
   children: ReactElement;
@@ -22,7 +24,14 @@ function SidebarIcons(props: ISidebarIconsProps) {
 
 export default function EditorSidebarControl() {
   const state = useSelector((state: RootState) => state.status.editor);
+  const t = useTrans("editor.sideBar.");
   const dispatch = useDispatch();
+
+  const previewOpenIcon: IIconProps = { iconName: 'Video', style: { transform: "scale(1.2)" } };
+  const previewCloseIcon: IIconProps = { iconName: 'VideoOff', style: { transform: "scale(1.2)" } };
+  const gameConfigIcon: IIconProps = { iconName: 'Settings', style: { transform: "scale(1.2)" } };
+  const assetsIcon: IIconProps = { iconName: 'Media', style: { transform: "scale(1.2)" } };
+  const scenesIcon: IIconProps = { iconName: 'MyMoviesTV', style: { transform: "scale(1.2)" } };
 
   function switchPreview() {
     dispatch(setEditorPreviewShow(!state.showPreview));
@@ -40,29 +49,24 @@ export default function EditorSidebarControl() {
     <div onClick={switchPreview}>
       <SidebarIcons isActive={state.showPreview}>
         <>
-          {state.showPreview && <PreviewOpen theme="outline" size="24" fill="#0B346E" strokeWidth={3} />}
-          {!state.showPreview && <PreviewCloseOne theme="outline" size="24" fill="#666" strokeWidth={3} />}
+          {state.showPreview && <IconButton iconProps={previewOpenIcon} title="showPreview" ariaLabel="showPreview" />}
+          {!state.showPreview && <IconButton iconProps={previewCloseIcon} title="closePreview" ariaLabel="closePreview" />}
         </>
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.gameconfig)} style={{ margin: "auto 0 0 0" }}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.gameconfig}>
-        <SettingConfig theme="outline" size="24"
-          fill={state.currentSidebarTag === sidebarTag.gameconfig ? "#0B346E" : "#666"} strokeWidth={3} />
+        <IconButton iconProps={gameConfigIcon} title={t("gameConfigs.title")} ariaLabel={t("gameConfigs.title")} />
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.assets)}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.assets}>
-        <FolderOpen theme="outline" size="24"
-          fill={state.currentSidebarTag === sidebarTag.assets ? "#0B346E" : "#666"}
-          strokeWidth={3} />
+        <IconButton iconProps={assetsIcon} title={t("assets.title")} ariaLabel={t("assets.title")} />
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.scenes)}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.scenes}>
-        <PlayTwo theme="outline" size="24"
-          fill={state.currentSidebarTag === sidebarTag.scenes ? "#0B346E" : "#666"}
-          strokeWidth={3} />
+        <IconButton iconProps={scenesIcon} title={t("scenes.title")} ariaLabel={t("scenes.title")} />
       </SidebarIcons>
     </div>
   </div>;

--- a/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
+++ b/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
@@ -2,10 +2,13 @@ import styles from "./editorSideBar.module.scss";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../../store/origineStore";
 import { ReactElement } from "react";
+import { FolderOpen, PlayTwo, PreviewCloseOne, PreviewOpen, SettingConfig } from "@icon-park/react";
 import { setEditorPreviewShow, setEditorSidebarTag, sidebarTag } from "../../../store/statusReducer";
 import useTrans from "@/hooks/useTrans";
 import { IIconProps } from '@fluentui/react';
 import { IconButton } from '@fluentui/react/lib/Button';
+import { registerIcons } from '@fluentui/react/lib/Styling';
+import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 
 interface ISidebarIconsProps {
   children: ReactElement;
@@ -27,11 +30,22 @@ export default function EditorSidebarControl() {
   const t = useTrans("editor.sideBar.");
   const dispatch = useDispatch();
 
-  const previewOpenIcon: IIconProps = { iconName: 'Video', style: { transform: "scale(1.2)" } };
-  const previewCloseIcon: IIconProps = { iconName: 'VideoOff', style: { transform: "scale(1.2)" } };
-  const gameConfigIcon: IIconProps = { iconName: 'Settings', style: { transform: "scale(1.2)" } };
-  const assetsIcon: IIconProps = { iconName: 'Media', style: { transform: "scale(1.2)" } };
-  const scenesIcon: IIconProps = { iconName: 'MyMoviesTV', style: { transform: "scale(1.2)" } };
+  // Register custom SVG icons
+  registerIcons({
+    icons: {
+      previewOpen: <PreviewOpen/>,
+      previewClose: <PreviewCloseOne/>,
+      gameConfig: <SettingConfig/>,
+      assets: <FolderOpen/>,
+      scenes: <PlayTwo/>,
+    }
+  });
+
+  const previewOpenIcon: IIconProps = { iconName: 'previewOpen', style: { transform: "scale(1.2)" } };
+  const previewCloseIcon: IIconProps = { iconName: 'previewClose', style: { transform: "scale(1.2)" } };
+  const gameConfigIcon: IIconProps = { iconName: 'gameConfig', style: { transform: "scale(1.2)" } };
+  const assetsIcon: IIconProps = { iconName: 'assets', style: { transform: "scale(1.2)" } };
+  const scenesIcon: IIconProps = { iconName: 'scenes', style: { transform: "scale(1.2)" } };
 
   function switchPreview() {
     dispatch(setEditorPreviewShow(!state.showPreview));
@@ -48,23 +62,30 @@ export default function EditorSidebarControl() {
   return <div className={styles.editor_sidebar_control}>
     <div onClick={switchPreview}>
       <SidebarIcons isActive={state.showPreview}>
-        <IconButton iconProps={state.showPreview ? previewOpenIcon : previewCloseIcon}
-          title={t("preview.title")} ariaLabel={t("preview.title")} />
+        <TooltipHost content={t("preview.title")}>
+          <IconButton iconProps={state.showPreview ? previewOpenIcon : previewCloseIcon}/>
+        </TooltipHost>
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.gameconfig)} style={{ margin: "auto 0 0 0" }}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.gameconfig}>
-        <IconButton iconProps={gameConfigIcon} title={t("gameConfigs.title")} ariaLabel={t("gameConfigs.title")} />
+        <TooltipHost content={t("gameConfigs.title")}>
+          <IconButton iconProps={gameConfigIcon}/>
+        </TooltipHost>
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.assets)}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.assets}>
-        <IconButton iconProps={assetsIcon} title={t("assets.title")} ariaLabel={t("assets.title")} />
+        <TooltipHost content={t("assets.title")}>
+          <IconButton iconProps={assetsIcon}/>
+        </TooltipHost>
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.scenes)}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.scenes}>
-        <IconButton iconProps={scenesIcon} title={t("scenes.title")} ariaLabel={t("scenes.title")} />
+        <TooltipHost content={t("scenes.title")}>
+          <IconButton iconProps={scenesIcon}/>
+        </TooltipHost>
       </SidebarIcons>
     </div>
   </div>;

--- a/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
+++ b/packages/origine2/src/pages/editor/EditorSidebar/EditorSidebarControl.tsx
@@ -1,14 +1,14 @@
 import styles from "./editorSideBar.module.scss";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "../../../store/origineStore";
-import { ReactElement } from "react";
-import { FolderOpen, PlayTwo, PreviewCloseOne, PreviewOpen, SettingConfig } from "@icon-park/react";
-import { setEditorPreviewShow, setEditorSidebarTag, sidebarTag } from "../../../store/statusReducer";
+import {useDispatch, useSelector} from "react-redux";
+import {RootState} from "../../../store/origineStore";
+import {ReactElement} from "react";
+import {FolderOpen, PlayTwo, PreviewCloseOne, PreviewOpen, SettingConfig} from "@icon-park/react";
+import {setEditorPreviewShow, setEditorSidebarTag, sidebarTag} from "../../../store/statusReducer";
 import useTrans from "@/hooks/useTrans";
-import { IIconProps } from '@fluentui/react';
-import { IconButton } from '@fluentui/react/lib/Button';
-import { registerIcons } from '@fluentui/react/lib/Styling';
-import { TooltipHost } from '@fluentui/react/lib/Tooltip';
+import {IIconProps} from '@fluentui/react';
+import {IconButton} from '@fluentui/react/lib/Button';
+import {registerIcons} from '@fluentui/react/lib/Styling';
+import {TooltipHost} from '@fluentui/react/lib/Tooltip';
 
 interface ISidebarIconsProps {
   children: ReactElement;
@@ -29,23 +29,32 @@ export default function EditorSidebarControl() {
   const state = useSelector((state: RootState) => state.status.editor);
   const t = useTrans("editor.sideBar.");
   const dispatch = useDispatch();
+  const size = 22;
+  const sizeStr = `${size}px`;
 
   // Register custom SVG icons
   registerIcons({
     icons: {
-      previewOpen: <PreviewOpen/>,
-      previewClose: <PreviewCloseOne/>,
-      gameConfig: <SettingConfig/>,
-      assets: <FolderOpen/>,
-      scenes: <PlayTwo/>,
+      previewOpen: <PreviewOpen size={size} theme="outline" fill="#0B346E" strokeWidth={3}/>,
+      previewClose: <PreviewCloseOne size={size} theme="outline" fill="#666" strokeWidth={3}/>,
+      gameConfig: <SettingConfig size={size} theme="outline" fill="#0B346E" strokeWidth={3}/>,
+      gameConfigClose: <SettingConfig size={size} theme="outline" fill="#666" strokeWidth={3}/>,
+      assetsOpen: <FolderOpen size={size} theme="outline" fill="#0B346E" strokeWidth={3}/>, // assets when open or active
+      assetsClose: <FolderOpen size={size} theme="outline" fill="#666" strokeWidth={3}/>,  // assets when closed or inactive
+      scenesOpen: <PlayTwo size={size} theme="outline" fill="#0B346E" strokeWidth={3}/>,    // scenes when open or active
+      scenesClose: <PlayTwo size={size} theme="outline" fill="#666" strokeWidth={3}/>       // scenes when closed or inactive
     }
   });
 
-  const previewOpenIcon: IIconProps = { iconName: 'previewOpen', style: { transform: "scale(1.2)" } };
-  const previewCloseIcon: IIconProps = { iconName: 'previewClose', style: { transform: "scale(1.2)" } };
-  const gameConfigIcon: IIconProps = { iconName: 'gameConfig', style: { transform: "scale(1.2)" } };
-  const assetsIcon: IIconProps = { iconName: 'assets', style: { transform: "scale(1.2)" } };
-  const scenesIcon: IIconProps = { iconName: 'scenes', style: { transform: "scale(1.2)" } };
+  const previewOpenIcon: IIconProps = {iconName: 'previewOpen', style: {height: size, lineHeight: sizeStr}};
+  const previewCloseIcon: IIconProps = {iconName: 'previewClose', style: {height: size, lineHeight: sizeStr}};
+  const gameConfigOpenIcon: IIconProps = {iconName: 'gameConfig', style: {height: size, lineHeight: sizeStr}};        // When open or active
+  const gameConfigCloseIcon: IIconProps = {iconName: 'gameConfigClose', style: {height: size, lineHeight: sizeStr}};  // When closed or inactive
+  const assetsOpenIcon: IIconProps = {iconName: 'assetsOpen', style: {height: size, lineHeight: sizeStr}};            // When open or active
+  const assetsCloseIcon: IIconProps = {iconName: 'assetsClose', style: {height: size, lineHeight: sizeStr}};          // When closed or inactive
+  const scenesOpenIcon: IIconProps = {iconName: 'scenesOpen', style: {height: size, lineHeight: sizeStr}};            // When open or active
+  const scenesCloseIcon: IIconProps = {iconName: 'scenesClose', style: {height: size, lineHeight: sizeStr}};          // When closed or inactive
+
 
   function switchPreview() {
     dispatch(setEditorPreviewShow(!state.showPreview));
@@ -67,24 +76,27 @@ export default function EditorSidebarControl() {
         </TooltipHost>
       </SidebarIcons>
     </div>
-    <div onClick={() => switchSidebarTag(sidebarTag.gameconfig)} style={{ margin: "auto 0 0 0" }}>
+    <div onClick={() => switchSidebarTag(sidebarTag.gameconfig)} style={{margin: "auto 0 0 0"}}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.gameconfig}>
         <TooltipHost content={t("gameConfigs.title")}>
-          <IconButton iconProps={gameConfigIcon}/>
+          <IconButton
+            iconProps={state.currentSidebarTag === sidebarTag.gameconfig ? gameConfigOpenIcon : gameConfigCloseIcon}/>
         </TooltipHost>
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.assets)}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.assets}>
         <TooltipHost content={t("assets.title")}>
-          <IconButton iconProps={assetsIcon}/>
+          <IconButton
+            iconProps={state.currentSidebarTag === sidebarTag.assets ? assetsOpenIcon : assetsCloseIcon}/>
         </TooltipHost>
       </SidebarIcons>
     </div>
     <div onClick={() => switchSidebarTag(sidebarTag.scenes)}>
       <SidebarIcons isActive={state.currentSidebarTag === sidebarTag.scenes}>
         <TooltipHost content={t("scenes.title")}>
-          <IconButton iconProps={scenesIcon}/>
+          <IconButton
+            iconProps={state.currentSidebarTag === sidebarTag.scenes ? scenesOpenIcon : scenesCloseIcon}/>
         </TooltipHost>
       </SidebarIcons>
     </div>

--- a/packages/origine2/src/pages/editor/EditorSidebar/editorSideBar.module.scss
+++ b/packages/origine2/src/pages/editor/EditorSidebar/editorSideBar.module.scss
@@ -34,7 +34,7 @@
 .editor_sidebar_control_button_active {
   //border: 1px solid rgba(0, 0, 0, 0.15);
   //box-shadow: 0 0 5px rgba(0, 0, 0, 0.15);
-  background: rgba(0, 0, 0, 0.15);
+  background: rgba(0, 0, 0, 0.1);
 }
 
 .preview_title {

--- a/packages/origine2/src/pages/editor/EditorSidebar/editorSideBar.module.scss
+++ b/packages/origine2/src/pages/editor/EditorSidebar/editorSideBar.module.scss
@@ -25,7 +25,6 @@
 }
 
 .editor_sidebar_control_button {
-  padding: 6px 6px 3px 6px;
   border-radius: 3px;
   //border: 1px solid rgba(0, 0, 0, 0.1);
   cursor: pointer;
@@ -35,7 +34,7 @@
 .editor_sidebar_control_button_active {
   //border: 1px solid rgba(0, 0, 0, 0.15);
   //box-shadow: 0 0 5px rgba(0, 0, 0, 0.15);
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.15);
 }
 
 .preview_title {
@@ -91,11 +90,11 @@
 
 }
 
- .editor_sidebar {
+.editor_sidebar {
   user-select: none;
 }
 
-.livePreviewNotice{
+.livePreviewNotice {
   color: #005caf;
   margin: 5px;
   padding: 5px;


### PR DESCRIPTION
Instead, use Fluent UI Icon material and Button to load icons in 'EditorSidebarControl' component for unification and easy theme changes.