### PR TITLE
feat: graphical editor hotkey

### DIFF
--- a/packages/origine2/src/components/Assets/Assets.tsx
+++ b/packages/origine2/src/components/Assets/Assets.tsx
@@ -47,8 +47,8 @@ const MoreVerticalIcon = bundleIcon(MoreVerticalFilled, MoreVerticalRegular);
 const ArrowExportUpIcon = bundleIcon(ArrowExportUpFilled, ArrowExportUpRegular);
 const ArrowSyncIcon = bundleIcon(ArrowSyncFilled, ArrowSyncRegular);
 
-export default function Assets({ basePath, isProtected = false, fileConfig, fileFunction }:
-  { basePath: string[], isProtected?: boolean, fileConfig?: IFileConfig, fileFunction?: IFileFunction }) {
+export default function Assets({ basePath, isProtected = false, fileConfig, fileFunction, recentlyFile }:
+  { basePath: string[], isProtected?: boolean, fileConfig?: IFileConfig, fileFunction?: IFileFunction, recentlyFile?: IFile[] }) {
   const { mutate } = useSWRConfig();
 
   const currentPath = useValue(basePath);
@@ -266,7 +266,36 @@ export default function Assets({ basePath, isProtected = false, fileConfig, file
               </PopoverSurface>
             </Popover>
           </>}
-
+          {recentlyFile &&
+            <Menu>
+              <MenuTrigger>
+                <Button icon={<ArrowSyncIcon />} size='small' />
+              </MenuTrigger>
+              <MenuPopover>
+                <MenuList>
+                  {
+                    recentlyFile
+                      ?.filter(file => file.name.toLocaleLowerCase().includes(filterText.value.toLocaleLowerCase()))
+                      .map(file =>
+                        (fileConfig?.get(`${currentPathString}/${file.name}`)?.isHidden) // 判断是否隐藏
+                          ? null
+                          : <FileElement
+                            key={file.name}
+                            file={file}
+                            desc={fileConfig?.get(`${currentPathString}/${file.name}`)?.desc ?? undefined}
+                            currentPath={currentPath}
+                            isProtected={fileConfig?.get(`${currentPathString}/${file.name}`)?.isProtected ?? isProtected}
+                            handleOpenFile={handleOpenFile}
+                            handleRenameFile={handleRenameFile}
+                            handleDeleteFile={handleDeleteFile}
+                            checkHasFile={checkHasFile}
+                          />
+                      )
+                  }
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          }
           <Menu>
             <MenuTrigger>
               <Button icon={<MoreVerticalIcon />} size='small' />

--- a/packages/origine2/src/components/Assets/FileElement.tsx
+++ b/packages/origine2/src/components/Assets/FileElement.tsx
@@ -34,7 +34,9 @@ export default function FileElement(
     <div
       ref={FileItemSelfRef}
       key={file.name}
+      tabIndex={0}
       onClick={() => handleOpenFile(file)}
+      onKeyDown={(e) => {if (e.key === "Enter") {handleOpenFile(file);}}}
       className={styles.file}
     >
       {!file.isDir && <IconWrapper src={getFileIcon(file.name)} size={22} iconSize={20} />}

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -30,7 +30,7 @@ msgstr "<0>Apply a new template</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>Current template: {currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:180
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:216
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,11 @@ msgstr "Intro texts"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:174
 msgid "Live2D 动作"
 msgstr "Live2D Motion"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:196
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:184
 msgid "Live2D 表情"
 msgstr "Live2D Expression"
 
@@ -176,7 +176,7 @@ msgstr " Y："
 msgid "Y轴缩放："
 msgstr " Scale y："
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:172
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:208
 msgid "z-index"
 msgstr "z-index"
 
@@ -184,8 +184,8 @@ msgstr "z-index"
 msgid "一直显示功能区"
 msgstr "Always Show Toolbar"
 
-#: src/components/Assets/Assets.tsx:369
-#: src/components/Assets/Assets.tsx:370
+#: src/components/Assets/Assets.tsx:378
+#: src/components/Assets/Assets.tsx:379
 msgid "上传"
 msgstr "Upload"
 
@@ -294,7 +294,7 @@ msgstr "Use prepared apply target, if target set the ID, it won't apply"
 msgid "使用预设目标"
 msgstr "Use prepared target"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:214
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:202
 msgid "例如：-100,-100,100,100"
 msgstr "For example: -100,-100,100,100 "
 
@@ -477,7 +477,7 @@ msgstr "Delete"
 msgid "删除属性"
 msgstr "Delete Property"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:241
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:255
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:28
 msgid "删除本句"
 msgstr "Delete this sentence"
@@ -492,7 +492,8 @@ msgstr "Delete template"
 msgid "删除游戏"
 msgstr "Delete game"
 
-#: src/components/Assets/Assets.tsx:276
+#: src/components/Assets/Assets.tsx:275
+#: src/components/Assets/Assets.tsx:285
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:151
 msgid "刷新"
 msgstr "Refresh"
@@ -514,7 +515,7 @@ msgstr "Bold"
 msgid "动画"
 msgstr "Animation"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:299
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:298
 msgid "半张嘴"
 msgstr "Half open mouth"
 
@@ -575,7 +576,7 @@ msgstr "Enabled"
 msgid "启用视频跳过"
 msgstr "Enable video skipping"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:277
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:276
 msgid "唇形同步与眨眼"
 msgstr "Lip sync and blinking"
 
@@ -686,6 +687,10 @@ msgstr "Width"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:106
 msgid "对话"
 msgstr "Dialogue"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:77
+msgid "对话;"
+msgstr ""
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/GetUserInput.tsx:32
 msgid "对话框标题"
@@ -809,7 +814,7 @@ msgstr "Apply color changes"
 msgid "延迟时间（秒）"
 msgstr "Delay time (seconds)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:287
 msgid "张开嘴"
 msgstr "Open mouth"
 
@@ -837,16 +842,16 @@ msgid "手动输入 ID"
 msgstr "Manually enter ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:78
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:246
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:245
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
 msgid "打开效果编辑器"
 msgstr "Open effect editor"
 
-#: src/components/Assets/Assets.tsx:277
+#: src/components/Assets/Assets.tsx:286
 msgid "打开文件夹"
 msgstr "Open folder"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:249
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:263
 msgid "执行到此句"
 msgstr "Execute to this sentence"
 
@@ -856,8 +861,8 @@ msgstr "Extension name"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:88
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:91
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:261
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:258
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:260
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:53
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:56
 msgid "持续时间（单位为毫秒）"
@@ -900,7 +905,7 @@ msgstr "Tip: After editing, if you find any invalid CG/BGM in the appreciation g
 msgid "提示：换行符最多可达三行"
 msgstr "Tip: Line breaks can be up to three lines"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:254
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:253
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "Tip: The effect will only take place when switching to a different character sprite or closing the current sprite and adding it again. If you want to set an effect for an existing sprite, please use a separate command for setting effects."
 
@@ -955,7 +960,7 @@ msgid "效果编辑"
 msgstr "Effect editing"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:249
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
 msgid "效果编辑器"
 msgstr "Effect editor"
@@ -1109,7 +1114,7 @@ msgid "显示侧边栏"
 msgstr "Show sidebar"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:75
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:243
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "显示效果"
 msgstr "Display effect"
 
@@ -1145,11 +1150,11 @@ msgstr "Unrecognized"
 msgid "未识别的指令"
 msgstr "Unrecognized command"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:212
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:226
 msgid "本句前插入句子"
 msgstr "Insert sentence before this"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:163
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:177
 msgid "本句后插入句子"
 msgstr ""
 
@@ -1290,7 +1295,7 @@ msgstr "Add new line"
 msgid "添加自定义属性"
 msgstr "Add Custom Property"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:265
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:279
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:63
 #: src/pages/editor/Topbar/Topbar.tsx:108
 msgid "添加语句"
@@ -1371,7 +1376,7 @@ msgstr "No file currently open"
 msgid "相对"
 msgstr "Relative"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:320
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:319
 msgid "睁开眼睛"
 msgstr "Open eyes"
 
@@ -1415,7 +1420,7 @@ msgstr "Disabled"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:239
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:238
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:161
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:68
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:95
@@ -1423,11 +1428,11 @@ msgstr "Figure"
 msgid "立绘 ID"
 msgstr "Figure ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:231
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:230
 msgid "立绘ID（可选）"
 msgstr "Figure ID (optional)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:221
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "立绘位置"
 msgstr "Figure position"
 
@@ -1543,7 +1548,7 @@ msgstr "Auto-hide toolbar"
 msgid "自定义"
 msgstr "Customization"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:194
 msgid "自定义 Live2D 绘制范围"
 msgstr "Custom Live2D drawing area"
 
@@ -1590,8 +1595,8 @@ msgid "角色名，留空以继承上句"
 msgstr "Role name, leave blank to inherit from previous sentence"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:77
-msgid "角色名，留空以继承上句:对话;"
-msgstr "Role name, leave blank to inherit from previous sentence: Dialogue;"
+#~ msgid "角色名，留空以继承上句:对话;"
+#~ msgstr "Role name, leave blank to inherit from previous sentence: Dialogue;"
 
 #: src/pages/templateEditor/TemplateEditorSidebar/ComponentTree/ComponentTree.tsx:38
 msgid "角色名内层文本"
@@ -1705,7 +1710,7 @@ msgstr "Assets"
 msgid "输入目标 ID"
 msgstr "Enter Target ID"
 
-#: src/components/Assets/Assets.tsx:285
+#: src/components/Assets/Assets.tsx:294
 msgid "过滤文件"
 msgstr "Filter files"
 
@@ -1853,11 +1858,11 @@ msgstr "Appreciation Asset File"
 msgid "鉴赏音乐"
 msgstr "Appreciation Music"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:309
 msgid "闭上嘴"
 msgstr "Close Mouth"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:330
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:329
 msgid "闭上眼睛"
 msgstr "Close Eyes"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -30,7 +30,7 @@ msgstr "<0>新しいテンプレートを適用する</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>現在適用中のテンプレート：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:180
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:216
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,11 @@ msgstr "Intro テキスト"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:174
 msgid "Live2D 动作"
 msgstr "Live2D モーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:196
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:184
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -176,7 +176,7 @@ msgstr " Y軸位移："
 msgid "Y轴缩放："
 msgstr " Y軸スケール："
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:172
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:208
 msgid "z-index"
 msgstr "z-index"
 
@@ -184,8 +184,8 @@ msgstr "z-index"
 msgid "一直显示功能区"
 msgstr "常にツールバーを表示"
 
-#: src/components/Assets/Assets.tsx:369
-#: src/components/Assets/Assets.tsx:370
+#: src/components/Assets/Assets.tsx:378
+#: src/components/Assets/Assets.tsx:379
 msgid "上传"
 msgstr "アップロード"
 
@@ -294,7 +294,7 @@ msgstr "以前に設定されたアクションターゲットを使用。IDを�
 msgid "使用预设目标"
 msgstr "事前設定されたターゲットを使用"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:214
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:202
 msgid "例如：-100,-100,100,100"
 msgstr "例えば：-100,-100,100,100"
 
@@ -477,7 +477,7 @@ msgstr "削除"
 msgid "删除属性"
 msgstr "属性を削除"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:241
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:255
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:28
 msgid "删除本句"
 msgstr "この文を削除"
@@ -492,7 +492,8 @@ msgstr "テンプレートを削除"
 msgid "删除游戏"
 msgstr "ゲームを削除"
 
-#: src/components/Assets/Assets.tsx:276
+#: src/components/Assets/Assets.tsx:275
+#: src/components/Assets/Assets.tsx:285
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:151
 msgid "刷新"
 msgstr "更新"
@@ -514,7 +515,7 @@ msgstr "太字"
 msgid "动画"
 msgstr "アニメーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:299
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:298
 msgid "半张嘴"
 msgstr "半分開いた口"
 
@@ -575,7 +576,7 @@ msgstr "有効化"
 msgid "启用视频跳过"
 msgstr "動画のスキップを有効にする"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:277
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:276
 msgid "唇形同步与眨眼"
 msgstr "口パクとまばたき"
 
@@ -686,6 +687,10 @@ msgstr "幅"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:106
 msgid "对话"
 msgstr "ダイアログ"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:77
+msgid "对话;"
+msgstr ""
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/GetUserInput.tsx:32
 msgid "对话框标题"
@@ -809,7 +814,7 @@ msgstr "色の変更を適用"
 msgid "延迟时间（秒）"
 msgstr "遅延時間（秒）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:287
 msgid "张开嘴"
 msgstr "開いた口"
 
@@ -837,16 +842,16 @@ msgid "手动输入 ID"
 msgstr "IDを手動で設定"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:78
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:246
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:245
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
 msgid "打开效果编辑器"
 msgstr "エフェクトエディタを開く"
 
-#: src/components/Assets/Assets.tsx:277
+#: src/components/Assets/Assets.tsx:286
 msgid "打开文件夹"
 msgstr "フォルダーを開く"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:249
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:263
 msgid "执行到此句"
 msgstr "この文まで実行"
 
@@ -856,8 +861,8 @@ msgstr "拡張子"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:88
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:91
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:261
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:258
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:260
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:53
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:56
 msgid "持续时间（单位为毫秒）"
@@ -900,7 +905,7 @@ msgstr "ヒント: 編集後に無効なCG/BGMが見つかった場合は、WebG
 msgid "提示：换行符最多可达三行"
 msgstr "ヒント:改行は三行まで可能"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:254
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:253
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "ヒント：この効果は、異なる立ち絵に切り替えるか、一度立ち絵を閉じてから再度追加した場合にのみ有効です。既存の立ち絵に効果を設定する場合は、個別の効果設定コマンドを使用してください。"
 
@@ -955,7 +960,7 @@ msgid "效果编辑"
 msgstr "エフェクトエディタ"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:249
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
 msgid "效果编辑器"
 msgstr "エフェクトエディタ"
@@ -1109,7 +1114,7 @@ msgid "显示侧边栏"
 msgstr "サイドバーを表示"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:75
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:243
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "显示效果"
 msgstr "エフェクト"
 
@@ -1145,11 +1150,11 @@ msgstr "認識されないコマンド"
 msgid "未识别的指令"
 msgstr "認識されないコマンド"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:212
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:226
 msgid "本句前插入句子"
 msgstr "選択した文の前に追加"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:163
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:177
 msgid "本句后插入句子"
 msgstr ""
 
@@ -1290,7 +1295,7 @@ msgstr "新しい行を追加"
 msgid "添加自定义属性"
 msgstr "カスタム属性を追加"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:265
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:279
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:63
 #: src/pages/editor/Topbar/Topbar.tsx:108
 msgid "添加语句"
@@ -1371,7 +1376,7 @@ msgstr "現在開いているファイルはありません"
 msgid "相对"
 msgstr "相対"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:320
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:319
 msgid "睁开眼睛"
 msgstr "開いた目"
 
@@ -1415,7 +1420,7 @@ msgstr "無効化"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:239
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:238
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:161
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:68
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:95
@@ -1423,11 +1428,11 @@ msgstr "Figure"
 msgid "立绘 ID"
 msgstr "立ち絵ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:231
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:230
 msgid "立绘ID（可选）"
 msgstr "立ち絵ID(オプション)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:221
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "立绘位置"
 msgstr "描画位置"
 
@@ -1543,7 +1548,7 @@ msgstr "ツールバーを自動的に隠す"
 msgid "自定义"
 msgstr "カスタム"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:194
 msgid "自定义 Live2D 绘制范围"
 msgstr "Live2D 描画範囲のカスタマイズ"
 
@@ -1590,8 +1595,8 @@ msgid "角色名，留空以继承上句"
 msgstr "キャラクター名を空白のままにすると前の文から継承"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:77
-msgid "角色名，留空以继承上句:对话;"
-msgstr "キャラクター名を空白のままにすると前の文から継承;ダイアログ;"
+#~ msgid "角色名，留空以继承上句:对话;"
+#~ msgstr "キャラクター名を空白のままにすると前の文から継承;ダイアログ;"
 
 #: src/pages/templateEditor/TemplateEditorSidebar/ComponentTree/ComponentTree.tsx:38
 msgid "角色名内层文本"
@@ -1705,7 +1710,7 @@ msgstr "アセット"
 msgid "输入目标 ID"
 msgstr "ターゲットIDを入力"
 
-#: src/components/Assets/Assets.tsx:285
+#: src/components/Assets/Assets.tsx:294
 msgid "过滤文件"
 msgstr "ファイルのフィルタリング"
 
@@ -1853,11 +1858,11 @@ msgstr "CG/BGMファイルを選択"
 msgid "鉴赏音乐"
 msgstr "BGM鑑賞"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:309
 msgid "闭上嘴"
 msgstr "閉じた口"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:330
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:329
 msgid "闭上眼睛"
 msgstr "閉じた目"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -46,7 +46,7 @@ msgstr "<0>应用新的模板</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>当前应用的模板：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:180
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:216
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -110,11 +110,11 @@ msgstr "Intro 文本"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:186
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:174
 msgid "Live2D 动作"
 msgstr "Live2D 动作"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:196
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:184
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -192,7 +192,7 @@ msgstr "Y轴位移："
 msgid "Y轴缩放："
 msgstr "Y轴缩放："
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:172
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:208
 msgid "z-index"
 msgstr "z-index"
 
@@ -200,8 +200,8 @@ msgstr "z-index"
 msgid "一直显示功能区"
 msgstr "一直显示功能区"
 
-#: src/components/Assets/Assets.tsx:369
-#: src/components/Assets/Assets.tsx:370
+#: src/components/Assets/Assets.tsx:378
+#: src/components/Assets/Assets.tsx:379
 msgid "上传"
 msgstr "上传"
 
@@ -314,7 +314,7 @@ msgstr "使用预设的作用目标，如果设置了id则不生效"
 msgid "使用预设目标"
 msgstr "使用预设目标"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:214
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:202
 msgid "例如：-100,-100,100,100"
 msgstr "例如：-100,-100,100,100"
 
@@ -497,7 +497,7 @@ msgstr "删除"
 msgid "删除属性"
 msgstr "删除属性"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:241
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:255
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:28
 msgid "删除本句"
 msgstr "删除本句"
@@ -512,7 +512,8 @@ msgstr "删除模板"
 msgid "删除游戏"
 msgstr "删除游戏"
 
-#: src/components/Assets/Assets.tsx:276
+#: src/components/Assets/Assets.tsx:275
+#: src/components/Assets/Assets.tsx:285
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:151
 msgid "刷新"
 msgstr "刷新"
@@ -534,7 +535,7 @@ msgstr "加粗"
 msgid "动画"
 msgstr "动画"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:299
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:298
 msgid "半张嘴"
 msgstr "半张嘴"
 
@@ -595,7 +596,7 @@ msgstr "启用"
 msgid "启用视频跳过"
 msgstr "启用视频跳过"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:277
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:276
 msgid "唇形同步与眨眼"
 msgstr "唇形同步与眨眼"
 
@@ -706,6 +707,10 @@ msgstr "宽度"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:106
 msgid "对话"
 msgstr "对话"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:77
+msgid "对话;"
+msgstr "对话;"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/GetUserInput.tsx:32
 msgid "对话框标题"
@@ -829,7 +834,7 @@ msgstr "应用颜色变化"
 msgid "延迟时间（秒）"
 msgstr "延迟时间（秒）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:287
 msgid "张开嘴"
 msgstr "张开嘴"
 
@@ -857,16 +862,16 @@ msgid "手动输入 ID"
 msgstr "手动输入 ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:78
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:246
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:245
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:44
 msgid "打开效果编辑器"
 msgstr "打开效果编辑器"
 
-#: src/components/Assets/Assets.tsx:277
+#: src/components/Assets/Assets.tsx:286
 msgid "打开文件夹"
 msgstr "打开文件夹"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:249
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:263
 msgid "执行到此句"
 msgstr "执行到此句"
 
@@ -876,8 +881,8 @@ msgstr "扩展名"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:88
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:91
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:261
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:258
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:260
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:53
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:56
 msgid "持续时间（单位为毫秒）"
@@ -920,7 +925,7 @@ msgstr "提示：在编辑结束后，如果发现有失效的鉴赏 CG/BGM ，�
 msgid "提示：换行符最多可达三行"
 msgstr "提示：换行符最多可达三行"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:254
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:253
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 
@@ -975,7 +980,7 @@ msgid "效果编辑"
 msgstr "效果编辑"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:249
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:46
 msgid "效果编辑器"
 msgstr "效果编辑器"
@@ -1129,7 +1134,7 @@ msgid "显示侧边栏"
 msgstr "显示侧边栏"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:75
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:243
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "显示效果"
 msgstr "显示效果"
 
@@ -1165,11 +1170,11 @@ msgstr "未识别"
 msgid "未识别的指令"
 msgstr "未识别的指令"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:212
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:226
 msgid "本句前插入句子"
 msgstr "本句前插入句子"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:163
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:177
 msgid "本句后插入句子"
 msgstr "本句后插入句子"
 
@@ -1310,7 +1315,7 @@ msgstr "添加新行"
 msgid "添加自定义属性"
 msgstr "添加自定义属性"
 
-#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:265
+#: src/pages/editor/GraphicalEditor/GraphicalEditor.tsx:279
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx:63
 #: src/pages/editor/Topbar/Topbar.tsx:108
 msgid "添加语句"
@@ -1391,7 +1396,7 @@ msgstr "目前没有打开任何文件"
 msgid "相对"
 msgstr "相对"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:320
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:319
 msgid "睁开眼睛"
 msgstr "睁开眼睛"
 
@@ -1435,7 +1440,7 @@ msgstr "禁用"
 msgid "立绘"
 msgstr "立绘"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:239
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:238
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:161
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:68
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:95
@@ -1443,11 +1448,11 @@ msgstr "立绘"
 msgid "立绘 ID"
 msgstr "立绘 ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:231
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:230
 msgid "立绘ID（可选）"
 msgstr "立绘ID（可选）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:221
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:220
 msgid "立绘位置"
 msgstr "立绘位置"
 
@@ -1563,7 +1568,7 @@ msgstr "自动隐藏功能区"
 msgid "自定义"
 msgstr "自定义"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:194
 msgid "自定义 Live2D 绘制范围"
 msgstr "自定义 Live2D 绘制范围"
 
@@ -1610,8 +1615,8 @@ msgid "角色名，留空以继承上句"
 msgstr "角色名，留空以继承上句"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:77
-msgid "角色名，留空以继承上句:对话;"
-msgstr "角色名，留空以继承上句:对话;"
+#~ msgid "角色名，留空以继承上句:对话;"
+#~ msgstr "角色名，留空以继承上句:对话;"
 
 #: src/pages/templateEditor/TemplateEditorSidebar/ComponentTree/ComponentTree.tsx:38
 msgid "角色名内层文本"
@@ -1725,7 +1730,7 @@ msgstr "资源"
 msgid "输入目标 ID"
 msgstr "输入目标 ID"
 
-#: src/components/Assets/Assets.tsx:285
+#: src/components/Assets/Assets.tsx:294
 msgid "过滤文件"
 msgstr "过滤文件"
 
@@ -1873,11 +1878,11 @@ msgstr "鉴赏资源文件"
 msgid "鉴赏音乐"
 msgstr "鉴赏音乐"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:309
 msgid "闭上嘴"
 msgstr "闭上嘴"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:330
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:329
 msgid "闭上眼睛"
 msgstr "闭上眼睛"
 

--- a/packages/origine2/src/pages/editor/ChooseFile/ChooseFile.tsx
+++ b/packages/origine2/src/pages/editor/ChooseFile/ChooseFile.tsx
@@ -15,6 +15,7 @@ export interface IChooseFile {
   // 拓展名，要加.
   extName: string[];
   hiddenFiles?: string[];
+  recentlyFiles?: IFile[];
   _hardBasePath?: string[]
 }
 
@@ -64,6 +65,7 @@ export default function ChooseFile(props: IChooseFile) {
             isProtected
             fileFunction={fileFunction}
             fileConfig={fileConfig}
+            recentlyFile={props.recentlyFiles}
           />
         </div>
       </PopoverSurface>

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -69,6 +69,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
       const firstTabElement = searchElement.querySelector("[tabindex]");
       if (firstTabElement instanceof HTMLElement) {
         firstTabElement.focus();
+        firstTabElement.scrollIntoView?.({behavior: 'auto'});
       }
     }
   }
@@ -80,7 +81,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     const showSentenceList = [...showSentence.value];
     showSentenceList.splice(updateIndex, 0, true);
     showSentence.set(showSentenceList);
-    focusOneSentence(updateIndex);
+    setTimeout(() => {focusOneSentence(updateIndex);}, 0);
   }
 
   function deleteOneSentence(index: number) {
@@ -202,7 +203,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
                   draggableId={sentence.content + sentence.commandRaw + i} index={i}>
                   {(provided, snapshot) => (
                     <div className={`${styles.sentenceEditorWrapper} sentence-block-${index}`} onKeyDown={handleSentenceKeyDown}
-                      key={sentence.commandRaw + JSON.stringify(sentence.sentenceAssets) + i + 'inner'}
+                      key={"Inner Draggable:" + i.toString()}
                       ref={provided.innerRef}
                       {...provided.draggableProps}
                     >

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
@@ -14,9 +14,12 @@ import {Button, Input} from "@fluentui/react-components";
 import useEditorStore from "@/store/useEditorStore";
 import {t} from "@lingui/macro";
 import WheelDropdown from "@/pages/editor/GraphicalEditor/components/WheelDropdown";
+import {IFile} from "@/components/Assets/Assets";
 
 type FigurePosition = "" | "left" | "right";
 type AnimationFlag = "" | "on";
+
+const figuresHistory: IFile[] = [];
 
 export default function ChangeFigure(props: ISentenceEditorProps) {
   const currentEdit = useEditorStore.use.subPage();
@@ -156,10 +159,13 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
           <>
             {figureFile.value + "\u00a0\u00a0"}
             <ChooseFile sourceBase="figure" onChange={(fileDesc) => {
+              if (fileDesc && !figuresHistory.some((file) => file.path === fileDesc.path)) {
+                figuresHistory.push(fileDesc);
+              }
               figureFile.set(fileDesc?.name ?? "");
               submit();
             }}
-            extName={[".png", ".jpg", ".webp", ".json"]}/>
+            extName={[".png", ".jpg", ".webp", ".json"]} recentlyFiles={figuresHistory}/>
           </>
         </CommonOptions>}
       <CommonOptions key="2" title={t`连续执行`}>
@@ -168,18 +174,6 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
           submit();
         }} onText={t`本句执行后执行下一句`}
         offText={t`本句执行后等待`} isChecked={isGoNext.value}/>
-      </CommonOptions>
-      <CommonOptions title={t`z-index`} key="z-index">
-        <input value={zIndex.value}
-          onChange={(ev) => {
-            const newValue = ev.target.value;
-            zIndex.set(newValue ?? "");
-          }}
-          onBlur={submit}
-          className={styles.sayInput}
-          placeholder={t`1, 2, 3, ...`}
-          style={{width: "100%"}}
-        />
       </CommonOptions>
       {figureFile.value.includes('.json') && (
         <>
@@ -217,7 +211,18 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
           </CommonOptions>
         </>
       )}
-
+      <CommonOptions title={t`z-index`} key="z-index">
+        <input value={zIndex.value}
+          onChange={(ev) => {
+            const newValue = ev.target.value;
+            zIndex.set(newValue ?? "");
+          }}
+          onBlur={submit}
+          className={styles.sayInput}
+          placeholder={t`1, 2, 3, ...`}
+          style={{width: "100%"}}
+        />
+      </CommonOptions>
       <CommonOptions title={t`立绘位置`} key="3">
         <WheelDropdown
           options={figurePositions}

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx
@@ -74,7 +74,7 @@ export const sentenceEditorConfig: ISentenceEditorConfig[] = [
   {
     type: commandType.say,
     title: () => t`普通对话`,
-    initialText: () => t`角色名，留空以继承上句:对话;`,
+    initialText: () => t`对话;`,
     component: Say,
     icon: <CommentOne className={styles.iconSvg} theme="multi-color" size="24"/>,
     descText: () => t`添加一句对话，可以附带语音`

--- a/packages/origine2/src/pages/editor/GraphicalEditor/components/AddSentence.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/components/AddSentence.tsx
@@ -46,10 +46,17 @@ const AddSentence = forwardRef<AddSentenceMethods, IAddSentenceProps>((props: IA
     </div>;
   });
   const addSentenceHotKey = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.ctrlKey && event.key === "1") {
-      event.preventDefault();
-      isShowCallout.set(false);
-      props.onChoose(sentenceConfigMap[0].initialText());
+    if (event.ctrlKey) {
+      if (event.key === "1") {
+        event.preventDefault();
+        isShowCallout.set(false);
+        props.onChoose(sentenceConfigMap[0].initialText());
+      }
+      else if (event.key === "2") {
+        event.preventDefault();
+        isShowCallout.set(false);
+        props.onChoose(sentenceConfigMap[2].initialText());
+      }
     }
   };
 


### PR DESCRIPTION
# 图像编辑器

## Sentence
修改了key使其仅仅与index、sentence类别和所处的层次(inner)相关
更好的支持Tab循环
shift + enter 可以快捷增加一个Sentence

## AddSentence
Ctrl + 1和Ctrl +2 可以快速选择Sentence类别（之后可以自定义）

## ChangeFigure
在ChooseFile，Asset加了recentlyFile的接口
该Asset立绘选择拥有历史选择

## Graphic Editor
添加了focusOneSentence 用于上述功能使用

## Index (fix)
对话的initialText减去前面错误的注释