### PR TITLE
fix: theme highlight and completion

### DIFF
--- a/packages/origine2/src/config/highlighting/hl.json
+++ b/packages/origine2/src/config/highlighting/hl.json
@@ -136,7 +136,7 @@
     },
     "character-colon": {
       "comment": "[char]:[utt[ -args]][;cmt]",
-      "match": "^(?!(?:intro|changeBg|changeFigure|miniAvatar|playEffect|changeScene|choose|end|bgm|playVideo|setComplexAnimation|setFilter|pixiInit|pixiPerform|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|say|filmMode|callScene|setTextbox|setAnimation|setTransition|setTransform|say|getUserInput|applyStyle|wait)\\:)(.*?)(\\:)([^\\;\\n]*?)($|\\;.*?$)",
+      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait)\\:)(.*?)(\\:)([^\\;\\n]*?)($|\\;.*?$)",
       "captures": {
         "1": {
           "name": "meta.character.webgal",
@@ -171,7 +171,7 @@
     },
     "command-colon": {
       "comment": "cmd:[arg0[ -args]][;cmt]",
-      "match": "^(intro|changeBg|changeFigure|playEffect|miniAvatar|changeScene|choose|end|bgm|playVideo|setComplexAnimation|setFilter|pixiInit|pixiPerform|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|say|filmMode|callScene|setTextbox|setAnimation|setTransition|setTransform|say|getUserInput|applyStyle|wait)(\\:)([^\\;\\n]*?)($|\\;.*?$)",
+      "match": "^(say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait)(\\:)([^\\;\\n]*?)($|\\;.*?$)",
       "captures": {
         "1": {
           "name": "meta.command.webgal",
@@ -206,7 +206,7 @@
     },
     "command-semicolon": {
       "comment": "cmd;[cmt]",
-      "match": "^(intro|changeBg|changeFigure|playEffect|miniAvatar|changeScene|choose|end|bgm|playVideo|setComplexAnimation|setFilter|pixiInit|pixiPerform|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|say|filmMode|callScene|setTextbox|setAnimation|setTransition|setTransform|say|getUserInput|applyStyle|wait)($|\\;.*?$)",
+      "match": "^(say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait)($|\\;.*?$)",
       "captures": {
         "1": {
           "name": "meta.command.webgal",
@@ -227,7 +227,7 @@
     },
     "utterance-semicolon": {
       "comment": "utt[ -args];[cmt]",
-      "match": "^(?!(?:intro|changeBg|changeFigure|playEffect|miniAvatar|changeScene|choose|end|bgm|playVideo|setComplexAnimation|setFilter|pixiInit|pixiPerform|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|say|filmMode|callScene|setTextbox|setAnimation|setTransition|setTransform|say|getUserInput|applyStyle|wait)\\;)([^\\:\\;\\n]+?)(\\;.*?$)",
+      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait)\\;)([^\\:\\;\\n]+?)($|\\;.*?$)",
       "captures": {
         "1": {
           "patterns": [

--- a/packages/origine2/src/config/themes/monokai-light-vs.json
+++ b/packages/origine2/src/config/themes/monokai-light-vs.json
@@ -7,7 +7,7 @@
     "editor.selectionBackground": "#ccc9ad8e",
     "editor.wordHighlightBackground": "#00000011",
     "editorCursor.foreground": "#666663",
-    "editorIndentGuide.background": "#D3D4D5",
+    "editorIndentGuide.background1": "#D3D4D5",
     "editorLineNumber.foreground": "#a2a19c",
     "editorWhitespace.foreground": "#bbbbb7"
   },
@@ -35,7 +35,7 @@
         "string.unquoted.utterance.webgal"
       ],
       "settings": {
-        "foreground": "#aca21a",
+        "foreground": "#9b9107",
         "fontStyle": "bold"
       }
     },
@@ -64,7 +64,7 @@
         "variable.parameter.webgal",
       ],
       "settings": {
-        "foreground": "#d88a14",
+        "foreground": "#bb7306",
       }
     },
     {
@@ -72,7 +72,7 @@
         "variable.other.webgal",
       ],
       "settings": {
-        "foreground": "#16c441",
+        "foreground": "#09ad32",
       }
     },
     {

--- a/packages/origine2/src/config/themes/vscode-dark-modern.json
+++ b/packages/origine2/src/config/themes/vscode-dark-modern.json
@@ -6,7 +6,7 @@
 		"editorIndentGuide.background1": "#404040",
 		"editorIndentGuide.activeBackground1": "#707070",
 		"editor.selectionHighlightBackground": "#ADD6FF26",
-		"editor.lineHighlightBackground": "#338bff15",
+		"editor.lineHighlightBackground": "#212831",
 		"editor.lineHighlightBorder": "#00000000",
 		"editor.selectionBackground": "#338bff45",
 		"editorCursor.foreground": "#ffffff",

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid ";注释"
 msgstr "Comment"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:436
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:437
 msgid "*设置拾色器后，点击此按钮以保存更改"
 msgstr "*Click this button to save changes after setting color picker"
 
@@ -440,7 +440,7 @@ msgstr "About"
 msgid "关联立绘"
 msgstr "Associated figure"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:372
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:373
 #: src/pages/editor/GraphicalEditor/components/SearchableCascader.tsx:228
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:149
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
@@ -989,7 +989,7 @@ msgstr "Apply"
 msgid "应用的模板"
 msgstr "Applied template"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:438
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:439
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:311
 msgid "应用颜色变化"
 msgstr "Apply color changes"
@@ -998,7 +998,7 @@ msgstr "Apply color changes"
 msgid "延迟时间（秒）"
 msgstr "Delay time (seconds)"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:371
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:372
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:148
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:145
@@ -2545,7 +2545,7 @@ msgid "高斯模糊"
 msgstr "Gaussian Blur"
 
 #: src/hooks/useEaseTypeOptions.ts:6
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:370
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:371
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:147
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
 msgid "默认"

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid ";注释"
 msgstr ";コメント"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:436
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:437
 msgid "*设置拾色器后，点击此按钮以保存更改"
 msgstr "*カラーピッカー設定後、このボタンで保存"
 
@@ -443,7 +443,7 @@ msgstr "About"
 msgid "关联立绘"
 msgstr "関連する立ち絵"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:372
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:373
 #: src/pages/editor/GraphicalEditor/components/SearchableCascader.tsx:228
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:149
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
@@ -992,7 +992,7 @@ msgstr "適用"
 msgid "应用的模板"
 msgstr "すでに適用されているテンプレート"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:438
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:439
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:311
 msgid "应用颜色变化"
 msgstr "色の変更を適用"
@@ -1001,7 +1001,7 @@ msgstr "色の変更を適用"
 msgid "延迟时间（秒）"
 msgstr "遅延時間（秒）"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:371
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:372
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:148
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:145
@@ -2544,7 +2544,7 @@ msgid "高斯模糊"
 msgstr "ぼかし"
 
 #: src/hooks/useEaseTypeOptions.ts:6
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:370
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:371
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:147
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
 msgid "默认"

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid ";注释"
 msgstr ";注释"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:436
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:437
 msgid "*设置拾色器后，点击此按钮以保存更改"
 msgstr "*设置拾色器后，点击此按钮以保存更改"
 
@@ -442,7 +442,7 @@ msgstr "关于"
 msgid "关联立绘"
 msgstr "关联立绘"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:372
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:373
 #: src/pages/editor/GraphicalEditor/components/SearchableCascader.tsx:228
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:149
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
@@ -991,7 +991,7 @@ msgstr "应用"
 msgid "应用的模板"
 msgstr "应用的模板"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:438
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:439
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx:311
 msgid "应用颜色变化"
 msgstr "应用颜色变化"
@@ -1000,7 +1000,7 @@ msgstr "应用颜色变化"
 msgid "延迟时间（秒）"
 msgstr "延迟时间（秒）"
 
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:371
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:372
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:148
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:96
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:145
@@ -2543,7 +2543,7 @@ msgid "高斯模糊"
 msgstr "高斯模糊"
 
 #: src/hooks/useEaseTypeOptions.ts:6
-#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:370
+#: src/pages/editor/GraphicalEditor/components/EffectEditor.tsx:371
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:147
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:58
 msgid "默认"

--- a/packages/terre2/src/Modules/lsp/suggestionRules/getArgsKey.ts
+++ b/packages/terre2/src/Modules/lsp/suggestionRules/getArgsKey.ts
@@ -17,12 +17,16 @@ export function getArgsKey(
         speakerKey,
         vocalKey,
         clearKey,
+        leftSayKey,
+        rightSayKey,
+        centerSayKey,
       ];
     }
     case commandType.changeBg: {
       return [
         whenKey,
         nextKey,
+        continueKey,
         durationKey,
         transformKey,
         unlocknameKey,
@@ -32,19 +36,11 @@ export function getArgsKey(
         easeKey,
       ];
     }
-    case commandType.choose: {
-      return [whenKey];
-    }
-    case commandType.getUserInput: {
-      return [whenKey, nextKey, titleKey, buttonTextKey, defaultValueKey];
-    }
-    case commandType.bgm: {
-      return [whenKey, volumeKey, enterBgmKey, unlocknameKey, seriesKey];
-    }
     case commandType.changeFigure: {
       return [
         whenKey,
         nextKey,
+        continueKey,
         durationKey,
         idFigureKey,
         leftKey,
@@ -63,12 +59,27 @@ export function getArgsKey(
         enterAnimationKey,
         exitAnimationKey,
         easeKey,
+        blinkKey,
+        focusKey,
       ];
+    }
+    case commandType.bgm: {
+      return [whenKey, volumeKey, enterBgmKey, unlocknameKey, seriesKey];
+    }
+    case commandType.video: {
+      return [whenKey, skipOffKey];
+    }
+    case commandType.pixi: {
+      return [whenKey];
+    }
+    case commandType.pixiInit: {
+      return [whenKey];
     }
     case commandType.intro: {
       return [
         whenKey,
         backgroundColorKey,
+        backgroundImageKey,
         fontColorKey,
         fontSizeKey,
         animationKey,
@@ -77,22 +88,62 @@ export function getArgsKey(
         userForwardKey,
       ];
     }
+    case commandType.miniAvatar: {
+      return [whenKey];
+    }
+    case commandType.changeScene: {
+      return [whenKey];
+    }
+    case commandType.choose: {
+      return [whenKey];
+    }
+    case commandType.end: {
+      return [whenKey];
+    }
+    case commandType.setComplexAnimation: {
+      return [whenKey, nextKey, continueKey, targetKey, durationKey];
+    }
+    case commandType.label: {
+      return [whenKey];
+    }
+    case commandType.jumpLabel: {
+      return [whenKey];
+    }
+    case commandType.setVar: {
+      return [whenKey, globalKey];
+    }
+    case commandType.callScene: {
+      return [whenKey];
+    }
+    case commandType.showVars: {
+      return [whenKey];
+    }
+    case commandType.unlockCg: {
+      return [whenKey, nameKey, seriesKey];
+    }
+    case commandType.unlockBgm: {
+      return [whenKey, nameKey, seriesKey];
+    }
+    case commandType.filmMode: {
+      return [whenKey];
+    }
+    case commandType.setTextbox: {
+      return [whenKey];
+    }
+    case commandType.setAnimation: {
+      return [whenKey, nextKey, continueKey, targetKey, writeDefaultKey, keepKey];
+    }
     case commandType.playEffect: {
       return [whenKey, volumeKey, idSoundKey];
     }
-    case commandType.video: {
-      return [whenKey, skipOffKey];
-    }
-    case commandType.setAnimation: {
-      return [whenKey, nextKey, targetKey, writeDefaultKey, keepKey];
-    }
     case commandType.setTempAnimation: {
-      return [whenKey, nextKey, targetKey, writeDefaultKey, keepKey];
+      return [whenKey, nextKey, continueKey, targetKey, writeDefaultKey, keepKey];
     }
     case commandType.setTransform: {
       return [
         whenKey,
         nextKey,
+        continueKey,
         targetKey,
         easeKey,
         writeDefaultKey,
@@ -103,17 +154,17 @@ export function getArgsKey(
     case commandType.setTransition: {
       return [whenKey, targetKey, enterAnimationKey, exitAnimationKey];
     }
-    case commandType.setVar: {
-      return [whenKey, globalKey];
+    case commandType.getUserInput: {
+      return [whenKey, titleKey, buttonTextKey, defaultValueKey];
     }
-    case commandType.unlockCg: {
-      return [whenKey, nameKey, seriesKey];
+    case commandType.applyStyle: {
+      return [whenKey];
     }
-    case commandType.unlockBgm: {
-      return [whenKey, nameKey, seriesKey];
+    case commandType.wait: {
+      return [whenKey];
     }
     default: {
-      return [whenKey];
+      return [whenKey, nextKey, continueKey];
     }
   }
 }
@@ -158,6 +209,23 @@ const nextKey: CompletionItem = {
 
 \`\`\`
 changeBg:testBG03.jpg -next; // 会立刻执行下一条语句
+\`\`\`
+  `),
+};
+
+const continueKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'continue',
+  insertText: 'continue',
+  detail: '继续执行',
+  documentation: markdown(`
+在某些情况下，你可能希望在执行完当前语句后继续执行下一条语句。这时可以使用 \`-continue\` 参数。
+此参数即使在用户未开启自动播放的情况下也会生效。
+
+示例：
+
+\`\`\`
+changeBg:testBG03.jpg -continue; // 会在当前语句执行完后继续执行下一条语句
 \`\`\`
   `),
 };
@@ -252,6 +320,48 @@ changeFigure:k2.png -next;
 \`\`\`
 这是第一句......;
 用户点击鼠标后才会转到第二句 -concat;
+\`\`\`
+  `),
+};
+
+const leftSayKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'left',
+  insertText: 'left',
+  detail: '对话属于左侧立绘',
+  documentation: markdown(`
+指定该对话所属的立绘为左侧立绘
+
+\`\`\`
+WebGAL:这是左侧立绘的对话 -left;
+\`\`\`
+  `),
+};
+
+const rightSayKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'right',
+  insertText: 'right',
+  detail: '对话属于右侧立绘',
+  documentation: markdown(`
+指定该对话所属的立绘为右侧立绘
+
+\`\`\`
+WebGAL:这是右侧立绘的对话 -right;
+\`\`\`
+  `),
+};
+
+const centerSayKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'center',
+  insertText: 'center',
+  detail: '对话属于中间立绘',
+  documentation: markdown(`
+指定该对话所属的立绘为中间立绘
+
+\`\`\`
+WebGAL:这是中间立绘的对话 -center;
 \`\`\`
   `),
 };
@@ -501,6 +611,42 @@ changeFigure:xxx.json -bounds=0,50,0,50;
   `),
 };
 
+const blinkKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'blink',
+  insertText: 'blink=',
+  detail: 'Live2D 立绘眨眼',
+  documentation: markdown(`
+设置 Live2D 立绘眨眼的参数, 参数有
+- blinkInterval: 眨眼间隔时间, 单位毫秒, 默认24小时
+- blinkIntervalRandom: 眨眼间隔时间随机范围, 单位毫秒, 默认1000
+- closingDuration: 眨眼闭合时间, 单位毫秒, 默认100
+- closedDuration: 眨眼闭合保持时间, 单位毫秒, 默认50
+- openingDuration: 眨眼睁开时间, 单位毫秒, 默认150
+
+\`\`\`
+changeFigure:xxx.json -blink={"blinkInterval":5000,"blinkIntervalRandom":2000,"closingDuration":100,"closedDuration":50,"openingDuration":150};
+\`\`\`
+  `),
+};
+
+const focusKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'focus',
+  insertText: 'focus=',
+  detail: 'Live2D 立绘注视',
+  documentation: markdown(`
+设置 Live2D 立绘的注视方向, 参数有
+- x: 注视点 X 坐标, 范围 -1.0 ~ 1.0, 默认 0.0
+- y: 注视点 Y 坐标, 范围 -1.0 ~ 1.0, 默认 0.0
+- instant: 是否立即生效, 布尔值, 默认 false
+
+\`\`\`
+changeFigure:xxx.json -focus={"x":0.5,"y":0.0,"instant":false};
+\`\`\`
+  `),
+};
+
 const unlocknameKey: CompletionItem = {
   kind: CompletionItemKind.Constant,
   label: 'unlockname',
@@ -559,7 +705,7 @@ const easeKey: CompletionItem = {
 const writeDefaultKey: CompletionItem = {
   kind: CompletionItemKind.Constant,
   label: 'writeDefault',
-  insertText: 'writeDefault=',
+  insertText: 'writeDefault',
   detail: '补充默认值',
   documentation: markdown(`
 若变换与效果中有未填写的属性时, 补充默认值, 否则继承现有的值
@@ -569,7 +715,7 @@ const writeDefaultKey: CompletionItem = {
 const keepKey: CompletionItem = {
   kind: CompletionItemKind.Constant,
   label: 'keep',
-  insertText: 'keep=',
+  insertText: 'keep',
   detail: '跨语句动画',
   documentation: markdown(`
 开启后, 动画可以跨对话播放, 直至被下一个同目标的
@@ -626,6 +772,16 @@ const backgroundColorKey: CompletionItem = {
   detail: '背景颜色',
   documentation: markdown(`
 指定背景颜色
+  `),
+};
+
+const backgroundImageKey: CompletionItem = {
+  kind: CompletionItemKind.Constant,
+  label: 'backgroundImage',
+  insertText: 'backgroundImage=',
+  detail: '背景图片',
+  documentation: markdown(`
+指定背景图片
   `),
 };
 

--- a/packages/terre2/src/Modules/lsp/suggestionRules/getCommands.ts
+++ b/packages/terre2/src/Modules/lsp/suggestionRules/getCommands.ts
@@ -12,15 +12,14 @@ function makeInsertText(text: string) {
 const commandSuggestions: CompletionItem[] = [
   {
     kind: CompletionItemKind.Function,
-    label: 'intro',
-    insertText: makeInsertText('intro'),
-    detail: `黑屏独白`,
+    label: 'say',
+    insertText: makeInsertText('say'),
+    detail: `角色对话/旁白`,
     documentation: markdown(
-      `在许多游戏中，会以黑屏显示一些文字，用来引入主题或表现人物的心理活动。你可以使用 intro 命令来演出独白。
-独白的分拆以分隔符(|)来分割，也就是说，每一个 | 代表一个换行。
-\`\`\`
-intro:回忆不需要适合的剧本，|反正一说出口，|都成了戏言。;
-intro:<text> [|<text of line 2>] ...;
+      `\`\`\`
+say:你好，世界！ -speaker=WebGAL;
+say:这是一句旁白 -clear;
+say:<text>;
 \`\`\``,
     ),
   },
@@ -45,6 +44,69 @@ changeBg:<fileName> [-next];
       `\`\`\`
 changeFigure:testFigure03.png -left -next;
 changeFigure:<fileName> [-left] [-right] [id=figureId] [-next];
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'bgm',
+    insertText: makeInsertText('bgm'),
+    detail: `背景音乐（BGM）`,
+    documentation: markdown(
+      `\`\`\`
+bgm:夏影.mp3;
+bgm:<fileName>;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'playVideo',
+    insertText: makeInsertText('playVideo'),
+    detail: `播放视频`,
+    documentation: markdown(
+      `\`\`\`
+playVideo:OP.mp4;
+playVideo:<fileName>;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'pixiPerform',
+    insertText: makeInsertText('pixiPerform'),
+    detail: `应用 Pixi 特效`,
+    documentation: markdown(
+      `注意：特效作用后，如果没有初始化，特效会一直运行。
+\`\`\`
+pixiPerform:<performName>;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'pixiInit',
+    insertText: 'pixiInit;',
+    detail: `初始化 Pixi 特效`,
+    documentation: markdown(
+      `1.如果你要使用特效，那么你必须先运行这个命令来初始化 Pixi。
+2.如果你想要消除已经作用的效果，你可以使用这个语法来清空效果。
+\`\`\`
+pixiInit;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'intro',
+    insertText: makeInsertText('intro'),
+    detail: `黑屏独白`,
+    documentation: markdown(
+      `在许多游戏中，会以黑屏显示一些文字，用来引入主题或表现人物的心理活动。你可以使用 intro 命令来演出独白。
+独白的分拆以分隔符(|)来分割，也就是说，每一个 | 代表一个换行。
+\`\`\`
+intro:回忆不需要适合的剧本，|反正一说出口，|都成了戏言。;
+intro:<text> [|<text of line 2>] ...;
 \`\`\``,
     ),
   },
@@ -77,19 +139,6 @@ changeScene:<newSceneFileName>;
   },
   {
     kind: CompletionItemKind.Function,
-    label: 'callScene',
-    insertText: makeInsertText('callScene'),
-    detail: `场景调用`,
-    documentation: markdown(
-      `如果你需要在执行完调用的场景后回到先前的场景（即父场景），你可以使用 callScene 来调用场景
-\`\`\`
-callScene:Chapter-2.txt;
-callScene:<newSceneFileName>;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
     label: 'choose',
     insertText: 'choose: | ;',
     detail: `分支选择`,
@@ -116,165 +165,14 @@ end;
   },
   {
     kind: CompletionItemKind.Function,
-    label: 'bgm',
-    insertText: makeInsertText('bgm'),
-    detail: `背景音乐（BGM）`,
+    label: 'setComplexAnimation',
+    insertText: makeInsertText('setComplexAnimation'),
+    detail: `设置复杂动画`,
     documentation: markdown(
-      `\`\`\`
-bgm:夏影.mp3;
-bgm:<fileName>;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'playEffect',
-    insertText: makeInsertText('playEffect'),
-    detail: `效果音`,
-    documentation: markdown(
-      `\`\`\`
-playEffect:xxx.mp3;
-playEffect:<fileName>;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'playVideo',
-    insertText: makeInsertText('playVideo'),
-    detail: `播放视频`,
-    documentation: markdown(
-      `\`\`\`
-playVideo:OP.mp4;
-playVideo:<fileName>;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'unlockCg',
-    insertText: makeInsertText('unlockCg'),
-    detail: `解锁 CG 鉴赏`,
-    documentation: markdown(
-      `\`\`\`
-unlockCg:xgmain.jpeg -name=星光咖啡馆与死神之蝶 -series=1;
-unlockCg:<fileName> -name=cgName -series=serisId;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'unlockBgm',
-    insertText: makeInsertText('unlockBgm'),
-    detail: `解锁 BGM 鉴赏`,
-    documentation: markdown(
-      `\`\`\`
-unlockBgm:s_Title.mp3 -name=Smiling-Swinging!!;
-unlockBgm:<fileName> -name=bgmName;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'setTextbox',
-    insertText: makeInsertText('setTextbox'),
-    detail: `设置文本框开启/关闭`,
-    documentation: markdown(
-      `\`\`\`
-setTextbox:hide;关闭文本框
-setTextbox:on;开启文本框，可以是除 hide 以外的任意值。
-setTextbox:[hide] [others];
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'setAnimation',
-    insertText: makeInsertText('setAnimation'),
-    detail: `设置动画`,
-    documentation: markdown(
-      `\`\`\`
-setAnimation:enter-from-bottom -target=fig-center -next;为中间立绘设置一个从下方进入的动画，并转到下一句。
-setAnimation:<animationName> -target=targetId;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'pixiInit',
-    insertText: 'pixiInit;',
-    detail: `初始化 Pixi 特效`,
-    documentation: markdown(
-      `1.如果你要使用特效，那么你必须先运行这个命令来初始化 Pixi。
-2.如果你想要消除已经作用的效果，你可以使用这个语法来清空效果。
+      `为已有的立绘或背景设置复杂动画效果
 \`\`\`
-pixiInit;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'pixiPerform',
-    insertText: makeInsertText('pixiPerform'),
-    detail: `应用 Pixi 特效`,
-    documentation: markdown(
-      `注意：特效作用后，如果没有初始化，特效会一直运行。
-\`\`\`
-pixiPerform:<performName>;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'setVar',
-    insertText: makeInsertText('setVar'),
-    detail: `设置变量`,
-    documentation: markdown(
-      `\`\`\`
-setVar:a=1;可以设置数字
-setVar:a=true;可以设置布尔值
-setVar:a=人物名称;可以设置字符串
-setVar:<expression>;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'getUserInput',
-    insertText: makeInsertText('getUserInput'),
-    detail: `获取用户输入`,
-    documentation: markdown(
-      `\`\`\`
-getUserInput:name -title=如何称呼你 -buttonText=确认; 将用户输入写入 name 变量中
-getUserInput:<varName> -title=titleText -buttonText=buttonText;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'setTransition',
-    insertText: makeInsertText('setTransition'),
-    detail: `设置进出场效果`,
-    documentation: markdown(
-      `注意：只有当立绘或背景被设置后，你才能为其设置进出场效果。
-设置进出场效果的代码写在立绘或背景的设置代码后。
-并且，设置进出场效果的语句必须紧随设置立绘或背景的语句连续执行，否则无法被正确应用。
-\`\`\`
-setTransition: -target=fig-center -enter=enter-from-bottom -exit=exit;
-setTransition: -target=targetId -enter=animationName -exit=animationName;
-\`\`\``,
-    ),
-  },
-  {
-    kind: CompletionItemKind.Function,
-    label: 'setTransform',
-    insertText: makeInsertText('setTransform'),
-    detail: `设置变换效果`,
-    documentation: markdown(
-      `为已有的立绘或背景设置变换效果
-\`\`\`
-setTransform: -target=fig-center -duration=500;
-setTransform: -target=<targetId> -duration=number;
+setComplexAnimation:universalSoftIn -target=fig-center;
+setComplexAnimation:<animationName> -target=<targetId>;
 \`\`\``,
     ),
   },
@@ -328,12 +226,177 @@ label:part_2; // 创建名为 part_2 的 label
   },
   {
     kind: CompletionItemKind.Function,
+    label: 'setVar',
+    insertText: makeInsertText('setVar'),
+    detail: `设置变量`,
+    documentation: markdown(
+      `\`\`\`
+setVar:a=1;可以设置数字
+setVar:a=true;可以设置布尔值
+setVar:a=人物名称;可以设置字符串
+setVar:<expression>;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'callScene',
+    insertText: makeInsertText('callScene'),
+    detail: `场景调用`,
+    documentation: markdown(
+      `如果你需要在执行完调用的场景后回到先前的场景（即父场景），你可以使用 callScene 来调用场景
+\`\`\`
+callScene:Chapter-2.txt;
+callScene:<newSceneFileName>;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'showVars',
+    insertText: makeInsertText('showVars'),
+    detail: `显示当前变量`,
+    documentation: markdown(
+      `调试时使用，显示当前所有变量及其数值
+\`\`\`
+showVars;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'unlockCg',
+    insertText: makeInsertText('unlockCg'),
+    detail: `解锁 CG 鉴赏`,
+    documentation: markdown(
+      `\`\`\`
+unlockCg:xgmain.jpeg -name=星光咖啡馆与死神之蝶 -series=1;
+unlockCg:<fileName> -name=cgName -series=serisId;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'unlockBgm',
+    insertText: makeInsertText('unlockBgm'),
+    detail: `解锁 BGM 鉴赏`,
+    documentation: markdown(
+      `\`\`\`
+unlockBgm:s_Title.mp3 -name=Smiling-Swinging!!;
+unlockBgm:<fileName> -name=bgmName;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
     label: 'filmMode',
     insertText: makeInsertText('filmMode'),
     detail: `电影模式`,
     documentation: markdown(
       `使用 \`filmMode:enable;\` 来开启电影模式。
 使用 \`filmMode:none;\` 来关闭电影模式。`,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'setTextbox',
+    insertText: makeInsertText('setTextbox'),
+    detail: `设置文本框开启/关闭`,
+    documentation: markdown(
+      `\`\`\`
+setTextbox:hide;关闭文本框
+setTextbox:on;开启文本框，可以是除 hide 以外的任意值。
+setTextbox:[hide] [others];
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'setAnimation',
+    insertText: makeInsertText('setAnimation'),
+    detail: `设置动画`,
+    documentation: markdown(
+      `\`\`\`
+setAnimation:enter-from-bottom -target=fig-center -next;为中间立绘设置一个从下方进入的动画，并转到下一句。
+setAnimation:<animationName> -target=targetId;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'playEffect',
+    insertText: makeInsertText('playEffect'),
+    detail: `效果音`,
+    documentation: markdown(
+      `\`\`\`
+playEffect:xxx.mp3;
+playEffect:<fileName>;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'setTempAnimation',
+    insertText: makeInsertText('setTempAnimation'),
+    detail: `设置多段动画`,
+    documentation: markdown(
+      `为已有的立绘或背景设置多段动画
+\`\`\`
+setTempAnimation:[{"duration":0},{"brightness":2,"contrast":0,"duration":200,"ease":"circIn"},{"brightness":1,"contrast":1,"duration":200},{"brightness":2,"contrast":0,"duration":200,"ease":"circIn"},{"brightness":1,"contrast":1,"duration":2500}] -target=fig-center;;
+setTempAnimation: -target=<targetId>r;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'setTransform',
+    insertText: makeInsertText('setTransform'),
+    detail: `设置变换效果`,
+    documentation: markdown(
+      `为已有的立绘或背景设置变换效果
+\`\`\`
+setTransform: -target=fig-center -duration=500;
+setTransform: -target=<targetId> -duration=number;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'setTransition',
+    insertText: makeInsertText('setTransition'),
+    detail: `设置进出场效果`,
+    documentation: markdown(
+      `注意：只有当立绘或背景被设置后，你才能为其设置进出场效果。
+设置进出场效果的代码写在立绘或背景的设置代码后。
+并且，设置进出场效果的语句必须紧随设置立绘或背景的语句连续执行，否则无法被正确应用。
+\`\`\`
+setTransition: -target=fig-center -enter=enter-from-bottom -exit=exit;
+setTransition: -target=targetId -enter=animationName -exit=animationName;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'getUserInput',
+    insertText: makeInsertText('getUserInput'),
+    detail: `获取用户输入`,
+    documentation: markdown(
+      `\`\`\`
+getUserInput:name -title=如何称呼你 -buttonText=确认; 将用户输入写入 name 变量中
+getUserInput:<varName> -title=titleText -buttonText=buttonText;
+\`\`\``,
+    ),
+  },
+  {
+    kind: CompletionItemKind.Function,
+    label: 'applyStyle',
+    insertText: makeInsertText('applyStyle'),
+    detail: `更换 UI 样式`,
+    documentation: markdown(
+      `\`\`\`
+applyStyle:TextBox_ShowName_Background->TextBox_ShowName_Background_Red;
+applyStyle:<origStyleName>-><newStyleName>(,<origStyleName2>-><newStyleName2>,...);
+\`\`\``,
     ),
   },
   {


### PR DESCRIPTION
# 介绍
一些关于文本编辑器的小调整, 主要是 主题, 补全, 高亮
- 主题
  - 修复了深色模式下, 等待输入法时, 文字会出现重影的问题(实际上也是主题色问题)
  - 微调了浅色模式下的主题色, 整体让文字压暗了一点
- 高亮
  - 补充了 `setTempAnimation` 的高亮
  - 调整了 Textmate 中命令的顺序, 使其与 commandType 顺序一致
  - 修复了纯对话, 无 speaker, 无参数, 无行内注释时, 高亮不生效的问题
- 补全
  - 补充了 `continue` `blink` `focus` 的参数补全
  - 补充了 `applyStyle` 的命令补全
  - 调整了命令补全 Item 的顺序, 使其与 commandType 顺序一致