### PR TITLE
feat: preserve inline comment

### DIFF
--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Bgm.tsx
@@ -33,6 +33,7 @@ export default function Bgm(props: ISentenceEditorProps) {
           {key: "series", value: ""},
         ]),
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/CallSteam.tsx
@@ -33,6 +33,7 @@ export default function CallSteam(props: ISentenceEditorProps) {
           { key: normalizedKey, value: paramValue.value, fullMode: true }
         ] : []),
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx
@@ -49,6 +49,7 @@ export default function ChangeBg(props: ISentenceEditorProps) {
         {key: "duration", value: duration.value},
         {key: "next", value: isGoNext.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeCallScene.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeCallScene.tsx
@@ -18,6 +18,7 @@ export default function ChangeCallScene(props: ISentenceEditorProps) {
       fileName.value,
       props.sentence.args,
       [],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
@@ -268,6 +268,7 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
         {key: "blendMode", value: blendMode.value},
         {key: "next", value: isGoNext.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Choose.tsx
@@ -19,6 +19,7 @@ export default function Choose(props: ISentenceEditorProps) {
       contentStr,
       props.sentence.args,
       [],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/GetUserInput.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/GetUserInput.tsx
@@ -22,6 +22,7 @@ export default function GetUserInput(props: ISentenceEditorProps) {
         {key: "title", value: title.value},
         {key: "buttonText", value: buttonText.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Intro.tsx
@@ -189,6 +189,7 @@ export default function Intro(props: ISentenceEditorProps) {
         {key: "hold", value: isHold.value},
         {key: "userForward", value: isUserForward.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/MiniAvatar.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/MiniAvatar.tsx
@@ -17,6 +17,7 @@ export default function MiniAvatar(props: ISentenceEditorProps) {
       fileName.value,
       props.sentence.args,
       [],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/PixiPerform.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/PixiPerform.tsx
@@ -27,6 +27,7 @@ export default function PixiPerform(props: ISentenceEditorProps) {
       isSetEffectsOff.value ? "" : effectName.value,
       props.sentence.args,
       [],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/PlayEffect.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/PlayEffect.tsx
@@ -23,6 +23,7 @@ export default function PlayEffect(props: ISentenceEditorProps) {
         {key: "volume", value: volume.value},
         {key: "id", value: id.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/PlayVideo.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/PlayVideo.tsx
@@ -20,6 +20,7 @@ export default function PlayVideo(props: ISentenceEditorProps) {
       [
         {key: "skipOff", value: isSkipOff.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx
@@ -103,6 +103,7 @@ export default function Say(props: ISentenceEditorProps) {
         {key: "id", value: figurePosition.value === "id"},
         {key: "figureId", value: (figurePosition.value === "id" ? figureId.value : "")},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx
@@ -40,6 +40,7 @@ export default function SetAnimation(props: ISentenceEditorProps) {
         {key: "keep", value: keep.value},
         {key: "next", value: isGoNext.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTextbox.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTextbox.tsx
@@ -14,6 +14,7 @@ export default function SetTextbox(props: ISentenceEditorProps) {
       isHideTextbox.value ? "hide" : "on",
       props.sentence.args,
       [],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx
@@ -53,6 +53,7 @@ export default function SetTransform(props: ISentenceEditorProps) {
         {key: "keep", value: keep.value},
         {key: "next", value: isGoNext.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/SetTransition.tsx
@@ -35,6 +35,7 @@ export default function SetTransition(props: ISentenceEditorProps) {
         {key: "exit", value: exitFileName.value},
         {key: "target", value: target.value},
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/UnlockExtra.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/UnlockExtra.tsx
@@ -33,6 +33,7 @@ export default function UnlockExtra(props: ISentenceEditorProps) {
           {key: "series", value: unlockSeries.value},
         ] : []),
       ],
+      props.sentence.inlineComment,
     );
     props.onSubmit(submitString);
   };

--- a/packages/origine2/src/utils/combineSubmitString.ts
+++ b/packages/origine2/src/utils/combineSubmitString.ts
@@ -6,6 +6,7 @@ import { arg } from "webgal-parser/src/interface/sceneInterface";
  * @param content 语句内容
  * @param originalArgs 原始参数数组
  * @param newArgs 新的参数数组, 若 fullMode 为 false, 会将值为 true 的 arg 简写为 -arg, 省略值为 false 或空字符串的 arg
+ * @param inlineComment 行内注释
  * @returns 合并后的用于提交的字符串
  */
 // eslint-disable-next-line max-params
@@ -13,7 +14,8 @@ export function combineSubmitString (
   commandStr: string | undefined,
   content: string,
   originalArgs: Array<arg>,
-  newArgs: Array<{key: string, value: string | boolean | number, fullMode?: boolean}>
+  newArgs: Array<{key: string, value: string | boolean | number, fullMode?: boolean}>,
+  inlineComment: string,
 ): string {
   const argStrings: Array<string> = [];
   const unsupportedArg = new Map<string, string | boolean | number>();
@@ -40,6 +42,10 @@ export function combineSubmitString (
     combinedString += `${commandStr}:`;
   }
   combinedString += `${content}${argStrings.join("")};`;
+
+  if (inlineComment && inlineComment.trim().length > 0) {
+    combinedString += ` ${inlineComment.trim()}`;
+  }
 
   return combinedString;
 }


### PR DESCRIPTION
# 介绍

图形编辑器提交语句时，可以保留行内注释。

> [!WARNING]
> 强烈建议在 OpenWebGAL/WebGAL#836 合并后
> 发布 webgal-parser 或者使用类似 yalc 的工具，更新此项目的 webgal-parser 依赖
> 否则编译不通过
