### PR TITLE
fix: fix check file name logic when create empty file

### DIFF
--- a/packages/terre2/src/Modules/webgal-fs/webgal-fs.service.spec.ts
+++ b/packages/terre2/src/Modules/webgal-fs/webgal-fs.service.spec.ts
@@ -1,18 +1,66 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { ConsoleLogger } from '@nestjs/common';
+import * as fs from 'fs/promises';
+import { join, resolve } from 'path';
 import { WebgalFsService } from './webgal-fs.service';
 
 describe('WebgalFsService', () => {
+  const testRoot = join(
+    process.cwd(),
+    'tmp',
+    'webgal-fs-service-spec',
+    `run-${Date.now()}`,
+  );
   let service: WebgalFsService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [WebgalFsService],
-    }).compile();
-
-    service = module.get<WebgalFsService>(WebgalFsService);
+    service = new WebgalFsService(new ConsoleLogger());
+    await fs.mkdir(testRoot, { recursive: true });
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  afterEach(async () => {
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('allows regular Windows absolute paths in segment validation', () => {
+    expect(
+      WebgalFsService.hasInvalidPathSegments(
+        'C:\\repo\\public\\games\\demo\\scene.txt',
+        'win32',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects invalid marks in path segments', () => {
+    expect(
+      WebgalFsService.hasInvalidPathSegments(
+        'C:\\repo\\public\\games\\bad|name.txt',
+        'win32',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects traversal path segments', () => {
+    expect(
+      WebgalFsService.hasInvalidPathSegments(
+        '/home/app/public/../secret.txt',
+        'linux',
+      ),
+    ).toBe(true);
+  });
+
+  it('creates an empty file for valid path', async () => {
+    const targetFilePath = join(testRoot, 'valid.txt');
+    const ret = await service.createEmptyFile(targetFilePath);
+    expect(ret).toBe('created');
+    await expect(fs.stat(targetFilePath)).resolves.toBeDefined();
+  });
+
+  it('blocks creating files out of workspace', async () => {
+    const outsidePath = join(
+      resolve(process.cwd(), '..'),
+      `webgal-fs-outside-${Date.now()}.txt`,
+    );
+    const ret = await service.createEmptyFile(outsidePath);
+    expect(ret).toBe('path error or no right.');
   });
 });


### PR DESCRIPTION
测试 #544 的时候，发现在 animation 文件夹里创建新的 .json 文件有问题，排查完发现是 #521 的提交导致的。

https://github.com/OpenWebGAL/WebGAL_Terre/blob/226a0c4cefa97ba3084242bee19dfbaacb4211d6/packages/terre2/src/Modules/webgal-fs/webgal-fs.service.ts#L228-L254

目前文件命名校验的逻辑写反了，创建 `test.json` 会失败，但创建 `test??.json` 可以成功，本 PR 旨在修正该逻辑。