### PR TITLE
fix: prevent nested folders from receiving special icons.

### DIFF
--- a/packages/origine2/src/utils/getFileIcon.ts
+++ b/packages/origine2/src/utils/getFileIcon.ts
@@ -65,9 +65,14 @@ fileMappings.set("tex", "image");
 fileMappings.set("video", "video");
 fileMappings.set("vocal", "audio");
 
+function hasSpecialAncestor(path: string[]): boolean {
+  return path.slice(0, -1).some(name => fileMappings.has(name));
+}
+
 // The function
 function getFileType(path: string): FileType {
   const splitPath = path.split(/[/\\]/); // handle both '/' and '\'
+  if (hasSpecialAncestor(splitPath)) return "unknown";
   const fileName = splitPath[splitPath.length - 1]; // get the last segment
   const fileType = fileMappings.get(fileName);
   return fileType ? fileType : "unknown";


### PR DESCRIPTION
fix: #525

为嵌套在特殊目录下, 拥有特殊名称的文件夹 (例如 `scene/figure`) 赋予特殊图标是无意义的.
这么做容易引起混淆, 而且其下的资源也无法使用