### PR TITLE
fix: prevent revert when deleting all script in script editor.

### DIFF
--- a/packages/origine2/src/pages/editor/TextEditor/TextEditor.tsx
+++ b/packages/origine2/src/pages/editor/TextEditor/TextEditor.tsx
@@ -115,7 +115,7 @@ export default function TextEditor(props: ITextEditorProps) {
     const lineNumber = editorLineHolder.getSceneLine(props.targetPath);
     // const lineNumber = ev.changes[0].range.startLineNumber;
     // const trueLineNumber = getTrueLinenumber(lineNumber, value ?? "");
-    if (value) currentText.current = value;
+    if (value || value === '') currentText.current = value;
     eventBus.emit('editor:update-scene', { scene: currentText.current });
     api.assetsControllerEditTextFile({textFile: currentText.current, path: props.targetPath}).then((res) => {
       const targetValue = currentText.current.split('\n')[lineNumber - 1];


### PR DESCRIPTION
fix: #562

原来的代码把空字符串误判为无效更改, 此处增加对空字符串的特判, 使其生效.