### PR TITLE
fix: remove leading empty line when editing empty file in graphical editor

### DIFF
--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -105,10 +105,19 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
     submitScene(newSentences, updateIndex);
   }
 
+  // 判断是否为空 (识别含唯一空行的文件)
+  function isEmpty(): boolean {
+    const sentences = sentenceData.value;
+    return !sentences || (sentences.length === 1 && sentences[0].content === "");
+  }
+
   function addOneSentence(newContent: string, insertIndex: number) {
     const newSentence = generateSentenceItem(newContent);
     const newSentences = [...sentenceData.value];
-    newSentences.splice(insertIndex, 0, newSentence);
+
+    if (!isEmpty()) newSentences.splice(insertIndex, 0, newSentence);
+    else newSentences.splice(insertIndex = 0, 1, newSentence); // 处理空文件
+
     sentenceData.set(newSentences);
     submitScene(newSentences, insertIndex);
   }

--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -106,20 +106,21 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
   }
 
   // 判断是否为空 (识别含唯一空行的文件)
-  function isEmpty(): boolean {
-    const sentences = sentenceData.value;
+  function isEmpty(sentences: SentenceItem[]): boolean {
     return !sentences || (sentences.length === 1 && sentences[0].content === "");
   }
 
   function addOneSentence(newContent: string, insertIndex: number) {
     const newSentence = generateSentenceItem(newContent);
     const newSentences = [...sentenceData.value];
+    const shouldReplaceEmptyLine = isEmpty(newSentences);
+    const targetInsertIndex = shouldReplaceEmptyLine ? 0 : insertIndex;
+    const deleteCount = shouldReplaceEmptyLine ? 1 : 0;
 
-    if (!isEmpty()) newSentences.splice(insertIndex, 0, newSentence);
-    else newSentences.splice(insertIndex = 0, 1, newSentence); // 处理空文件
+    newSentences.splice(targetInsertIndex, deleteCount, newSentence);
 
     sentenceData.set(newSentences);
-    submitScene(newSentences, insertIndex);
+    submitScene(newSentences, targetInsertIndex);
   }
 
   function deleteOneSentence(index: number) {


### PR DESCRIPTION
## 修复说明

在图形化编辑器中编辑空文件时，内置的空行被错误地视为一条语句。虽然渲染逻辑已对空文件做了保护，不会显示语句，但在执行添加语句操作时此保护失效，导致新语句前多出一条空语句。

本次修复新增 `isEmpty()` 检查，在 `addOneSentence(...)` 添加语句时若检测到空文件，则自动移除该多余空行。

## 前后对比

<table>
  <tr>
    <td align="center"><b>🐛 修复前</b><br>添加语句时顶部多出一条空语句</td>
    <td align="center"><b>✅ 修复后</b><br>空文件添加语句时不再产生多余空语句</td>
  </tr>
  <tr>
    <td align="center">
      <img width="581" height="382" alt="bug" src="https://github.com/user-attachments/assets/25ea7c75-2367-414c-a963-6a937b70f471" />
    </td>
    <td align="center">
      <img width="577" alt="fix" src="https://github.com/user-attachments/assets/159c2d96-442d-4188-bb0f-b26217de2019" />
    </td>
  </tr>
</table>