### PR TITLE
feat: add Mac Intel (x64) build support

### DIFF
--- a/.github/workflows/build-terre.yml
+++ b/.github/workflows/build-terre.yml
@@ -78,6 +78,28 @@ jobs:
         with:
           name: WebGAL_Terre_Mac
           path: release/WebGAL_Terre_Mac.zip
+  build-mac-x64:
+    name: Build MacOS x64 Binary
+    runs-on: macos-15-intel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+      - name: Build
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: sh release-mac-x64.sh
+      - name: Compress
+        run: 7z a -tzip release/WebGAL_Terre_Mac_Intel.zip release/*
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: WebGAL_Terre_Mac_Intel
+          path: release/WebGAL_Terre_Mac_Intel.zip
   build-windows:
     name: Build Windows Binary
     runs-on: windows-2022

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,28 @@ jobs:
         with:
           name: WebGAL_Terre_Mac
           path: release/WebGAL_Terre_Mac.zip
+  build-mac-x64:
+    name: Build MacOS x64 Binary
+    runs-on: macos-15-intel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+      - name: Build
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: sh release-mac-x64.sh
+      - name: Compress
+        run: 7z a -tzip release/WebGAL_Terre_Mac_Intel.zip release/*
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: WebGAL_Terre_Mac_Intel
+          path: release/WebGAL_Terre_Mac_Intel.zip
   build-windows:
     name: Build Windows Binary
     runs-on: windows-2022
@@ -164,7 +186,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: ['build-linux','build-arm64','build-mac','build-windows','build-windows-nsis','build-android']
+    needs: ['build-linux','build-arm64','build-mac','build-mac-x64','build-windows','build-windows-nsis','build-android']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -212,6 +234,16 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: WebGAL_Terre_Mac/WebGAL_Terre_Mac.zip
           asset_name: WebGAL_Terre_Mac_${{ github.ref_name }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload MacOS Intel Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: WebGAL_Terre_Mac_Intel/WebGAL_Terre_Mac_Intel.zip
+          asset_name: WebGAL_Terre_Mac_Intel_${{ github.ref_name }}.zip
           asset_content_type: application/zip
 
       - name: Upload Windows Asset

--- a/packages/terre2/package.json
+++ b/packages/terre2/package.json
@@ -24,6 +24,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "pkg": "tsx pkg-build.ts",
     "pkg:linux-arm64": "cross-env PKG_TARGET=node22-linux-arm64 tsx pkg-build.ts",
+    "pkg:mac-x64": "cross-env PKG_TARGET=node22-macos-x64 tsx pkg-build.ts",
     "update-exe-resources": "tsx update-exe-resources.ts"
   },
   "dependencies": {

--- a/release-mac-x64.sh
+++ b/release-mac-x64.sh
@@ -1,0 +1,91 @@
+echo "Welcome to build WebGAL Terre (Mac x64), the editor of WebGAL platform."
+# 安装依赖
+yarn install --frozen-lockfile --network-timeout=300000
+
+# 清理
+rm -rf release
+
+mkdir release
+
+# 进入 Terre 目录
+cd packages/terre2
+yarn run build
+yarn run pkg:mac-x64
+cd dist
+cp -r WebGAL_Terre  ../../../release
+rm WebGAL_Terre
+cd ../
+mkdir Exported_Games
+cp -r public assets Exported_Games ../../release
+cd ../../
+
+# 进入 Origine 目录
+cd packages/origine2
+#npm install esbuild-darwin-arm64
+export NODE_OPTIONS="--max-old-space-size=8192"
+yarn run build
+cp -rf dist/* ../../release/public/
+cd ../../
+
+# 进入 Electron 目录
+cd packages/WebGAL-electron
+yarn install --frozen-lockfile
+yarn run build
+# 拷贝 mac Steam API 动态库
+STEAM_API_DYLIB="node_modules/steamworks.js/dist/osx/libsteam_api.dylib"
+if [ -f "$STEAM_API_DYLIB" ]; then
+    TARGET_DIR="build/mac/WebGAL.app/Contents/Resources/app/node_modules/steamworks.js/dist/osx"
+    mkdir -p "$TARGET_DIR"
+    cp "$STEAM_API_DYLIB" "$TARGET_DIR/"
+else
+    echo "warning: Steamworks redistributable not found at $STEAM_API_DYLIB" >&2
+fi
+mkdir ../../release/assets/templates/WebGAL_Electron_Template
+cp -rf build/mac/WebGAL.app/* ../../release/assets/templates/WebGAL_Electron_Template/
+cd ../../
+
+# 克隆 WebGAL Android 模板
+cd release/assets/templates/
+git clone https://github.com/nini22P/WebGAL-Android.git
+mv WebGAL-Android WebGAL_Android_Template
+# MainActivity.kt 移动到主文件夹防止误删
+mv WebGAL_Android_Template/app/src/main/java/com/openwebgal/demo/MainActivity.kt WebGAL_Android_Template/app/src/main/java/MainActivity.kt
+cd ../../../
+
+cd release
+
+# 删除冗余文件
+rm -rf Exported_Games/*
+rm -rf public/games/*
+rm -rf public/games/.gitkeep
+rm -rf assets/templates/WebGAL_Template/game/video/*
+rm -rf assets/templates/WebGAL_Template/game/video/.gitkeep
+rm -rf assets/templates/WebGAL_Android_Template/.github
+rm -rf assets/templates/WebGAL_Android_Template/.git
+rm -rf assets/templates/WebGAL_Android_Template/.gitattributes
+rm -rf assets/templates/WebGAL_Android_Template/app/src/main/assets/webgal/.gitkeep
+rm -rf assets/templates/WebGAL_Android_Template/app/src/main/java/com
+
+cd ..
+mkdir release-mac
+mv release release-mac
+cd release-mac
+mv release WebGAL
+cd ..
+mv release-mac release
+cd release
+
+# 写脚本
+echo 'cd "$(dirname "$0")"' >> run-webgal-on-mac.command
+echo 'cd WebGAL' >> run-webgal-on-mac.command
+echo './WebGAL_Terre' >> run-webgal-on-mac.command
+chmod +x run-webgal-on-mac.command
+chmod +x WebGAL/WebGAL_Terre
+
+# readme 多语言提示（现阶段说明）
+echo '你需要为可执行文件设置正确的权限，并使用 run-webgal-on-mac.command 脚本才能正确使用 WebGAL Terre' > readme.txt
+echo 'You need to set the correct permissions for the executable file and use the run-webgal-on-mac.command script to use WebGAL Terre correctly' >> readme.txt
+echo 'WebGAL Terreを正しく使用するには、実行可能ファイルに正しいパーミッションを設定し、run-webgal-on-mac.command スクリプトを使用する必要があります。' >> readme.txt
+
+
+echo "WebGAL Terre (Mac x64) is now ready to be deployed."


### PR DESCRIPTION
## Summary

Add macOS Intel (x64) build support to resolve the "bad cpu type in executable" error reported by Intel Mac users.

## Changes

- `release-mac-x64.sh` - New build script for Intel Mac
  - Uses `pkg:mac-x64` to build the server binary for x64
  - Builds x64 Electron instead of universal
  - Adjusts Electron output paths (`build/mac/` instead of `build/mac-universal/`)
- `packages/terre2/package.json` - Added `pkg:mac-x64` script
- `.github/workflows/release.yml` - Added `build-mac-x64` job on `macos-13` (Intel runner), artifact upload, and release asset
- `.github/workflows/build-terre.yml` - Added `build-mac-x64` job for PR/main build checks

## Release artifact

New release zip: `WebGAL_Terre_Mac_Intel_{version}.zip`

Closes #569