### PR TITLE
fix: `\;` should not be highlighted as comment

### DIFF
--- a/packages/origine2/src/config/highlighting/hl.json
+++ b/packages/origine2/src/config/highlighting/hl.json
@@ -70,7 +70,7 @@
       "name": "support.function.command.webgal"
     },
     "comment-line": {
-      "match": "\\;.*?$",
+      "match": "(?<!\\\\);.*?$",
       "name": "comment.line.webgal"
     },
     "operator": {
@@ -136,7 +136,7 @@
     },
     "character-colon": {
       "comment": "[char]:[utt[ -args]][;cmt]",
-      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)\\:)(.*?)(\\:)([^\\;\\n]*?)($|\\;.*?$)",
+      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)\\:)(.*?)(\\:)((?:\\\\.|[^\\n])*?)($|(?<!\\\\);.*?$)",
       "captures": {
         "1": {
           "name": "meta.character.webgal",
@@ -171,7 +171,7 @@
     },
     "command-colon": {
       "comment": "cmd:[arg0[ -args]][;cmt]",
-      "match": "^(say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)(\\:)([^\\;\\n]*?)($|\\;.*?$)",
+      "match": "^(say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)(\\:)((?:\\\\.|[^\\n])*?)($|(?<!\\\\);.*?$)",
       "captures": {
         "1": {
           "name": "meta.command.webgal",
@@ -206,7 +206,7 @@
     },
     "command-semicolon": {
       "comment": "cmd;[cmt]",
-      "match": "^(say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)($|\\;.*?$)",
+      "match": "^(say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)($|(?<!\\\\);.*?$)",
       "captures": {
         "1": {
           "name": "meta.command.webgal",
@@ -227,7 +227,7 @@
     },
     "utterance-semicolon": {
       "comment": "utt[ -args];[cmt]",
-      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)\\;)([^\\:\\;\\n]+?)($|\\;.*?$)",
+      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)\\;)((?:\\\\.|[^\\n])+?)($|(?<!\\\\);.*?$)",
       "captures": {
         "1": {
           "patterns": [


### PR DESCRIPTION
脚本编辑器语法高亮配置有误, 将 `\;` 转义后的内容识别为了注释.

| 状态 | 效果截图 |
| :--- | :--- |
| **修复前** | <img width="537" height="25" alt="bug" src="https://github.com/user-attachments/assets/dd051045-d3cc-467d-ad45-cbd3e2ddc3ad" /> |
| **修复后** | <img width="537" height="25" alt="fix" src="https://github.com/user-attachments/assets/8918795f-675c-41ce-88c7-fe9c00c3cbd9" /> |