### PR TITLE
fix: prevent character-colon from consuming semicolon comment delimiter

### DIFF
--- a/packages/origine2/src/config/highlighting/hl.json
+++ b/packages/origine2/src/config/highlighting/hl.json
@@ -136,7 +136,7 @@
     },
     "character-colon": {
       "comment": "[char]:[utt[ -args]][;cmt]",
-      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)\\:)(.*?)(\\:)((?:\\\\.|[^\\n])*?)($|(?<!\\\\);.*?$)",
+      "match": "^(?!(?:say|changeBg|changeFigure|bgm|playVideo|pixiPerform|pixiInit|intro|miniAvatar|changeScene|choose|end|setComplexAnimation|label|jumpLabel|setVar|callScene|showVars|unlockCg|unlockBgm|filmMode|setTextbox|setAnimation|playEffect|setTempAnimation|setTransform|setTransition|getUserInput|applyStyle|wait|callSteam)\\:)((?:\\\\.|[^\\n;])*?)(\\:)((?:\\\\.|[^\\n])*?)($|(?<!\\\\);.*?$)",
       "captures": {
         "1": {
           "name": "meta.character.webgal",


### PR DESCRIPTION
脚本编辑器语法高亮配置有误: 当首个 `:` 出现在 `;` 后时, 会将 `:` 前的内容视为指令而非注释.

| 修复前 | 修复后 |
| --- | --- |
| <img width="157" height="78" alt="bug" src="https://github.com/user-attachments/assets/bf61ebd8-807b-4b60-a95e-7be194bebb3e" /> | <img width="150" height="74" alt="fix" src="https://github.com/user-attachments/assets/06c7aebf-0ff5-417a-bdaa-4e3257266556" /> |