### PR TITLE
feat: preview ready sync scene

### DIFF
--- a/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/GraphicalEditor.tsx
@@ -203,7 +203,7 @@ export default function GraphicalEditor(props: IGraphicalEditorProps) {
   }, [props.targetPath]);
 
   const syncCurrentLine = useCallback(() => {
-    const lineNumber = editorLineHolder.getSceneLine(props.targetPath) || 1;
+    const lineNumber = editorLineHolder.getSceneLineOrFirstLine(props.targetPath);
     EditorPreviewClient.sendSyncScene({
       scenePath: props.targetPath,
       lineNumber,

--- a/packages/origine2/src/pages/editor/TextEditor/TextEditor.tsx
+++ b/packages/origine2/src/pages/editor/TextEditor/TextEditor.tsx
@@ -132,7 +132,7 @@ export default function TextEditor(props: ITextEditorProps) {
   }, 500), []);
 
   const syncCurrentLine = useCallback(() => {
-    const lineNumber = editorLineHolder.getSceneLine(props.targetPath) || editorRef.current?.getPosition()?.lineNumber || 1;
+    const lineNumber = editorLineHolder.getSceneLineOrFirstLine(props.targetPath);
     EditorPreviewClient.sendSyncScene({
       scenePath: target?.path ?? '',
       lineNumber,

--- a/packages/origine2/src/runtime/WG_ORIGINE_RUNTIME.ts
+++ b/packages/origine2/src/runtime/WG_ORIGINE_RUNTIME.ts
@@ -10,7 +10,7 @@ export const lspSceneName = {value: ""};
 
 class EditorLineHolder{
   private mapSceneUrlToSentence = new Map<string,Position>();
-  
+
   public recordSceneEditingLine(sceneUrl: string, lineNumber: number) {
     this.mapSceneUrlToSentence.set(sceneUrl, new Position(lineNumber, 0));
     // console.log(this.mapSceneUrlToSentence);
@@ -23,6 +23,11 @@ class EditorLineHolder{
 
   public getSceneLine(sceneUrl: string): number {
     return this.mapSceneUrlToSentence.get(sceneUrl)?.lineNumber ?? 0;
+  }
+
+  public getSceneLineOrFirstLine(sceneUrl: string): number {
+    const lineNumber = this.getSceneLine(sceneUrl);
+    return lineNumber > 0 ? lineNumber : 1;
   }
 
   public getScenePosition(sceneUrl: string): Position {


### PR DESCRIPTION
## 变更内容

- 在 `EditorLineHolder` 中新增 `getSceneLineOrFirstLine`，统一处理场景同步行号回退规则
- `GraphicalEditor` 在预览 ready 后按记录行号同步当前场景，未记录时同步第 1 行
- `TextEditor` 在预览 ready 后不再使用 Monaco 默认 position 兜底，避免无明确光标记录时同步到非预期行

## 行为变化

- 打开实时预览并进入编辑页面后，预览 ready 时会同步当前打开的场景文件
- 有记录光标行时同步当前行
- 无记录光标行时同步第 1 行
- 当前实现会通过既有预览命令分发链路同步到已连接预览，不限定为 embedded preview

## 已知边界

- 本次暂不区分 embedded preview 和其他已连接预览
- 后续如果需要只同步 embedded preview，需要在 host/editor 协议或分发层补充更明确的目标路由